### PR TITLE
chore: upgrade to Rust edition 2024 and apply let-chain formatting

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,5 @@
 [workspace.package]
-edition = "2021"
+edition = "2024"
 license = "Apache-2.0"
 authors = ["GTS Community"]
 repository = "https://github.com/GlobalTypeSystem/gts-rust"

--- a/gts-cli/src/gen_schemas.rs
+++ b/gts-cli/src/gen_schemas.rs
@@ -1,4 +1,4 @@
-use anyhow::{bail, Result};
+use anyhow::{Result, bail};
 use gts::{GtsInstanceId, GtsSchemaId};
 use regex::Regex;
 use std::collections::HashMap;
@@ -140,7 +140,9 @@ pub fn generate_schemas_from_rust(
     println!("  Schemas generated: {schemas_generated}");
 
     if schemas_generated == 0 {
-        println!("\n- No schemas found. Make sure your structs are annotated with `#[struct_to_gts_schema(...)]`");
+        println!(
+            "\n- No schemas found. Make sure your structs are annotated with `#[struct_to_gts_schema(...)]`"
+        );
     }
 
     Ok(())
@@ -393,7 +395,8 @@ fn build_json_schema(
     required.sort();
 
     // Build schema based on whether this has a parent
-    let schema = match base {
+
+    match base {
         BaseAttr::IsBase => {
             // Base type - simple flat schema
             let mut s = json!({
@@ -445,9 +448,7 @@ fn build_json_schema(
 
             s
         }
-    };
-
-    schema
+    }
 }
 
 /// Derive parent schema ID from child schema ID

--- a/gts-cli/src/logging.rs
+++ b/gts-cli/src/logging.rs
@@ -95,32 +95,22 @@ impl LoggingMiddleware {
             };
 
             // Log request body at DEBUG level
-            if let Some(ref bytes) = body_bytes {
-                if !bytes.is_empty() {
-                    let timestamp = Local::now().format("%Y-%m-%d %H:%M:%S,%3f");
-                    if let Ok(json) = serde_json::from_slice::<serde_json::Value>(bytes) {
-                        let body_str = serde_json::to_string_pretty(&json).unwrap_or_default();
-                        eprintln!(
-                            "{} - DEBUG - {}Request body:{}\n{}{}{}",
-                            timestamp,
-                            colors.dim,
-                            colors.reset,
-                            colors.gray,
-                            body_str,
-                            colors.reset
-                        );
-                    } else {
-                        let body_str = String::from_utf8_lossy(bytes);
-                        eprintln!(
-                            "{} - DEBUG - {}Request body (raw):{}\n{}{}{}",
-                            timestamp,
-                            colors.dim,
-                            colors.reset,
-                            colors.gray,
-                            body_str,
-                            colors.reset
-                        );
-                    }
+            if let Some(ref bytes) = body_bytes
+                && !bytes.is_empty()
+            {
+                let timestamp = Local::now().format("%Y-%m-%d %H:%M:%S,%3f");
+                if let Ok(json) = serde_json::from_slice::<serde_json::Value>(bytes) {
+                    let body_str = serde_json::to_string_pretty(&json).unwrap_or_default();
+                    eprintln!(
+                        "{} - DEBUG - {}Request body:{}\n{}{}{}",
+                        timestamp, colors.dim, colors.reset, colors.gray, body_str, colors.reset
+                    );
+                } else {
+                    let body_str = String::from_utf8_lossy(bytes);
+                    eprintln!(
+                        "{} - DEBUG - {}Request body (raw):{}\n{}{}{}",
+                        timestamp, colors.dim, colors.reset, colors.gray, body_str, colors.reset
+                    );
                 }
             }
 

--- a/gts-cli/src/server.rs
+++ b/gts-cli/src/server.rs
@@ -1,14 +1,14 @@
 use axum::{
+    Json, Router,
     extract::{Path, Query, State},
     http::StatusCode,
     middleware,
     response::IntoResponse,
     routing::{get, post},
-    Json, Router,
 };
 use gts::GtsOps;
 use serde::Deserialize;
-use serde_json::{json, Value};
+use serde_json::{Value, json};
 use std::sync::{Arc, Mutex};
 
 use crate::logging::LoggingMiddleware;

--- a/gts-macros/tests/inheritance_tests.rs
+++ b/gts-macros/tests/inheritance_tests.rs
@@ -351,7 +351,10 @@ mod tests {
                 == "gts.x.core.events.type.v1~"
         );
         let _audit_payload_id = AuditPayloadV1::<()>::gts_schema_id().clone().into_string();
-        assert!(PlaceOrderDataV1::gts_schema_id().clone().into_string() == "gts.x.core.events.type.v1~x.core.audit.event.v1~x.marketplace.orders.purchase.v1~");
+        assert!(
+            PlaceOrderDataV1::gts_schema_id().clone().into_string()
+                == "gts.x.core.events.type.v1~x.core.audit.event.v1~x.marketplace.orders.purchase.v1~"
+        );
 
         // BaseEventV1 should have direct properties, no allOf
         assert!(
@@ -824,10 +827,10 @@ mod tests {
             serde_json::to_value(&topic_instance).expect("Should convert to JSON");
 
         // Ensure the config field is an empty object, not null
-        if let Some(config_obj) = instance_json.get_mut("config") {
-            if *config_obj == serde_json::Value::Null {
-                *config_obj = serde_json::json!({});
-            }
+        if let Some(config_obj) = instance_json.get_mut("config")
+            && *config_obj == serde_json::Value::Null
+        {
+            *config_obj = serde_json::json!({});
         }
 
         let add_result = ops.add_entity(&instance_json, true);
@@ -956,10 +959,10 @@ mod tests {
             .expect("TopicV1<OrderTopicConfigV1> should serialize");
 
         // Fix the config field for TopicV1<()> - convert null to {} to match schema
-        if let Some(config_obj) = topic_json.get_mut("config") {
-            if *config_obj == serde_json::Value::Null {
-                *config_obj = serde_json::json!({});
-            }
+        if let Some(config_obj) = topic_json.get_mut("config")
+            && *config_obj == serde_json::Value::Null
+        {
+            *config_obj = serde_json::json!({});
         }
 
         // Add instances to the store
@@ -1809,10 +1812,10 @@ mod tests {
 
     /// Helper to fix null config fields to empty objects for schema validation
     fn fix_null_config(json: &mut serde_json::Value) {
-        if let Some(config_obj) = json.get_mut("config") {
-            if *config_obj == serde_json::Value::Null {
-                *config_obj = serde_json::json!({});
-            }
+        if let Some(config_obj) = json.get_mut("config")
+            && *config_obj == serde_json::Value::Null
+        {
+            *config_obj = serde_json::json!({});
         }
     }
 

--- a/gts/src/files_reader.rs
+++ b/gts/src/files_reader.rs
@@ -61,28 +61,27 @@ impl GtsFileReader {
                     let path = entry.path();
 
                     // Skip excluded directories
-                    if path.is_dir() {
-                        if let Some(name) = path.file_name() {
-                            if EXCLUDE_LIST.contains(&name.to_string_lossy().as_ref()) {
-                                continue;
-                            }
-                        }
+                    if path.is_dir()
+                        && let Some(name) = path.file_name()
+                        && EXCLUDE_LIST.contains(&name.to_string_lossy().as_ref())
+                    {
+                        continue;
                     }
 
-                    if path.is_file() {
-                        if let Some(ext) = path.extension() {
-                            let ext_str = ext.to_string_lossy().to_lowercase();
-                            if VALID_EXTENSIONS.contains(&format!(".{ext_str}").as_str()) {
-                                let rp = path
-                                    .canonicalize()
-                                    .unwrap_or_else(|_| path.to_path_buf())
-                                    .to_string_lossy()
-                                    .to_string();
-                                if !seen.contains(&rp) {
-                                    seen.insert(rp.clone());
-                                    tracing::debug!("- discovered file: {:?}", path);
-                                    collected.push(PathBuf::from(rp));
-                                }
+                    if path.is_file()
+                        && let Some(ext) = path.extension()
+                    {
+                        let ext_str = ext.to_string_lossy().to_lowercase();
+                        if VALID_EXTENSIONS.contains(&format!(".{ext_str}").as_str()) {
+                            let rp = path
+                                .canonicalize()
+                                .unwrap_or_else(|_| path.to_path_buf())
+                                .to_string_lossy()
+                                .to_string();
+                            if !seen.contains(&rp) {
+                                seen.insert(rp.clone());
+                                tracing::debug!("- discovered file: {:?}", path);
+                                collected.push(PathBuf::from(rp));
                             }
                         }
                     }

--- a/gts/src/gts.rs
+++ b/gts/src/gts.rs
@@ -416,10 +416,10 @@ impl GtsID {
                 if p_seg.ver_major != 0 && p_seg.ver_major != c_seg.ver_major {
                     return false;
                 }
-                if let Some(p_minor) = p_seg.ver_minor {
-                    if Some(p_minor) != c_seg.ver_minor {
-                        return false;
-                    }
+                if let Some(p_minor) = p_seg.ver_minor
+                    && Some(p_minor) != c_seg.ver_minor
+                {
+                    return false;
                 }
                 if p_seg.is_type && p_seg.is_type != c_seg.is_type {
                     return false;
@@ -448,10 +448,10 @@ impl GtsID {
             }
 
             // Minor version: if pattern has no minor version, accept any minor in candidate
-            if let Some(p_minor) = p_seg.ver_minor {
-                if Some(p_minor) != c_seg.ver_minor {
-                    return false;
-                }
+            if let Some(p_minor) = p_seg.ver_minor
+                && Some(p_minor) != c_seg.ver_minor
+            {
+                return false;
             }
 
             // Check is_type flag matches
@@ -476,13 +476,13 @@ impl GtsID {
         let gts = parts[0].to_owned();
         let path = parts.get(1).map(|s| (*s).to_owned());
 
-        if let Some(ref p) = path {
-            if p.is_empty() {
-                return Err(GtsError::InvalidId {
-                    id: gts_with_path.to_owned(),
-                    cause: "Attribute path cannot be empty".to_owned(),
-                });
-            }
+        if let Some(ref p) = path
+            && p.is_empty()
+        {
+            return Err(GtsError::InvalidId {
+                id: gts_with_path.to_owned(),
+                cause: "Attribute path cannot be empty".to_owned(),
+            });
         }
 
         Ok((gts, path))
@@ -661,7 +661,7 @@ impl schemars::JsonSchema for GtsInstanceId {
         "GtsInstanceId".to_owned()
     }
 
-    fn json_schema(_: &mut schemars::gen::SchemaGenerator) -> schemars::schema::Schema {
+    fn json_schema(_: &mut schemars::r#gen::SchemaGenerator) -> schemars::schema::Schema {
         // Build schema from the shared JSON representation
         let json = Self::json_schema_value();
         let schema_obj = schemars::schema::SchemaObject {
@@ -828,7 +828,7 @@ impl schemars::JsonSchema for GtsSchemaId {
         "GtsSchemaId".to_owned()
     }
 
-    fn json_schema(_: &mut schemars::gen::SchemaGenerator) -> schemars::schema::Schema {
+    fn json_schema(_: &mut schemars::r#gen::SchemaGenerator) -> schemars::schema::Schema {
         // Build schema from the shared JSON representation
         let json = Self::json_schema_value();
         let schema_obj = schemars::schema::SchemaObject {

--- a/gts/src/lib.rs
+++ b/gts/src/lib.rs
@@ -14,7 +14,7 @@ pub use files_reader::GtsFileReader;
 pub use gts::{GtsError, GtsID, GtsIdSegment, GtsInstanceId, GtsSchemaId, GtsWildcard};
 pub use ops::GtsOps;
 pub use path_resolver::JsonPathResolver;
-pub use schema::{strip_schema_metadata, GtsSchema};
+pub use schema::{GtsSchema, strip_schema_metadata};
 pub use schema_cast::{GtsEntityCastResult, SchemaCastError};
 pub use store::{GtsReader, GtsStore, GtsStoreQueryResult, StoreError};
 pub use x_gts_ref::{XGtsRefValidationError, XGtsRefValidator};

--- a/gts/src/ops.rs
+++ b/gts/src/ops.rs
@@ -184,10 +184,10 @@ impl GtsOps {
 
     fn load_config(config_path: Option<String>) -> GtsConfig {
         // Try user-provided path
-        if let Some(path) = config_path {
-            if let Ok(cfg) = Self::load_config_from_path(&PathBuf::from(path)) {
-                return cfg;
-            }
+        if let Some(path) = config_path
+            && let Ok(cfg) = Self::load_config_from_path(&PathBuf::from(path))
+        {
+            return cfg;
         }
 
         // Try default path (relative to current directory)
@@ -289,7 +289,10 @@ impl GtsOps {
                         self.get_details(&entity)
                     )
                 } else {
-                    format!("Unable to detect ID in instance entity. Instances must have an 'id' field (or one of the configured entity_id_fields):\n{}", self.get_details(&entity))
+                    format!(
+                        "Unable to detect ID in instance entity. Instances must have an 'id' field (or one of the configured entity_id_fields):\n{}",
+                        self.get_details(&entity)
+                    )
                 },
             };
         };
@@ -309,35 +312,36 @@ impl GtsOps {
         }
 
         // Always validate schemas
-        if entity.is_schema {
-            if let Err(e) = self.store.validate_schema(&entity_id) {
-                return GtsAddEntityResult {
-                    ok: false,
-                    id: String::new(),
-                    schema_id: None,
-                    is_schema: false,
-                    error: format!(
-                        "Schema validation failed: {e}\n{}",
-                        self.get_details(&entity)
-                    ),
-                };
-            }
+        if entity.is_schema
+            && let Err(e) = self.store.validate_schema(&entity_id)
+        {
+            return GtsAddEntityResult {
+                ok: false,
+                id: String::new(),
+                schema_id: None,
+                is_schema: false,
+                error: format!(
+                    "Schema validation failed: {e}\n{}",
+                    self.get_details(&entity)
+                ),
+            };
         }
 
         // If validation is requested, validate the instance as well
-        if validate && !entity.is_schema {
-            if let Err(e) = self.store.validate_instance(&entity_id) {
-                return GtsAddEntityResult {
-                    ok: false,
-                    id: String::new(),
-                    schema_id: None,
-                    is_schema: false,
-                    error: format!(
-                        "Instance validation failed: {e}\n{}",
-                        self.get_details(&entity)
-                    ),
-                };
-            }
+        if validate
+            && !entity.is_schema
+            && let Err(e) = self.store.validate_instance(&entity_id)
+        {
+            return GtsAddEntityResult {
+                ok: false,
+                id: String::new(),
+                schema_id: None,
+                is_schema: false,
+                error: format!(
+                    "Instance validation failed: {e}\n{}",
+                    self.get_details(&entity)
+                ),
+            };
         }
 
         // println!("submitted: {}", self.get_content_pretty(&entity));
@@ -1136,11 +1140,13 @@ mod tests {
         );
         assert!(json.get("valid").expect("test").as_bool().expect("test"));
         assert!(json.get("is_schema").expect("test").as_bool().is_some());
-        assert!(!json
-            .get("is_wildcard")
-            .expect("test")
-            .as_bool()
-            .expect("test"));
+        assert!(
+            !json
+                .get("is_wildcard")
+                .expect("test")
+                .as_bool()
+                .expect("test")
+        );
     }
 
     #[test]
@@ -1298,11 +1304,13 @@ mod tests {
             json.get("id").expect("test").as_str().expect("test"),
             "gts.vendor.package.namespace.type.v1.0"
         );
-        assert!(!json
-            .get("is_schema")
-            .expect("test")
-            .as_bool()
-            .expect("test"));
+        assert!(
+            !json
+                .get("is_schema")
+                .expect("test")
+                .as_bool()
+                .expect("test")
+        );
         assert!(json.contains_key("schema_id"));
     }
 
@@ -1420,11 +1428,13 @@ mod tests {
         assert!(json.contains_key("schema_id"));
         assert!(json.contains_key("selected_entity_field"));
         assert!(json.contains_key("selected_schema_id_field"));
-        assert!(!json
-            .get("is_schema")
-            .expect("test")
-            .as_bool()
-            .expect("test"));
+        assert!(
+            !json
+                .get("is_schema")
+                .expect("test")
+                .as_bool()
+                .expect("test")
+        );
     }
 
     #[test]

--- a/gts/src/schema.rs
+++ b/gts/src/schema.rs
@@ -113,15 +113,13 @@ pub trait GtsSchema {
 
         // If we have a generic field, ensure it's just {"type": "object"} without additionalProperties
         // This field will be extended by child schemas
-        if let Some(gf) = generic_field {
-            if let Some(props) = current
+        if let Some(gf) = generic_field
+            && let Some(props) = current
                 .get_mut("properties")
                 .and_then(|v| v.as_object_mut())
-            {
-                if props.contains_key(gf) {
-                    props.insert(gf.to_owned(), serde_json::json!({"type": "object"}));
-                }
-            }
+            && props.contains_key(gf)
+        {
+            props.insert(gf.to_owned(), serde_json::json!({"type": "object"}));
         }
 
         // Wrap from inner to outer - parent levels don't need additionalProperties: false

--- a/gts/src/x_gts_ref.rs
+++ b/gts/src/x_gts_ref.rs
@@ -175,51 +175,45 @@ impl XGtsRefValidator {
         };
 
         // Check for x-gts-ref constraint
-        if let Some(x_gts_ref) = sch_obj.get("x-gts-ref") {
-            if let Some(inst_str) = inst.as_str() {
-                if let Some(ref_pattern) = x_gts_ref.as_str() {
-                    if let Some(error) =
-                        self.validate_ref_value(inst_str, ref_pattern, path, root_schema)
-                    {
-                        errors.push(error);
-                    }
-                }
-            }
+        if let Some(x_gts_ref) = sch_obj.get("x-gts-ref")
+            && let Some(inst_str) = inst.as_str()
+            && let Some(ref_pattern) = x_gts_ref.as_str()
+            && let Some(error) = self.validate_ref_value(inst_str, ref_pattern, path, root_schema)
+        {
+            errors.push(error);
         }
 
         // Recurse into object properties
         if let Some(Value::String(type_str)) = sch_obj.get("type") {
             if type_str == "object" {
-                if let Some(properties) = sch_obj.get("properties") {
-                    if let Some(properties_obj) = properties.as_object() {
-                        if let Some(inst_obj) = inst.as_object() {
-                            for (prop_name, prop_schema) in properties_obj {
-                                if let Some(prop_value) = inst_obj.get(prop_name) {
-                                    let prop_path = if path.is_empty() {
-                                        prop_name.clone()
-                                    } else {
-                                        format!("{path}.{prop_name}")
-                                    };
-                                    self.visit_instance(
-                                        prop_value,
-                                        prop_schema,
-                                        root_schema,
-                                        &prop_path,
-                                        errors,
-                                    );
-                                }
-                            }
+                if let Some(properties) = sch_obj.get("properties")
+                    && let Some(properties_obj) = properties.as_object()
+                    && let Some(inst_obj) = inst.as_object()
+                {
+                    for (prop_name, prop_schema) in properties_obj {
+                        if let Some(prop_value) = inst_obj.get(prop_name) {
+                            let prop_path = if path.is_empty() {
+                                prop_name.clone()
+                            } else {
+                                format!("{path}.{prop_name}")
+                            };
+                            self.visit_instance(
+                                prop_value,
+                                prop_schema,
+                                root_schema,
+                                &prop_path,
+                                errors,
+                            );
                         }
                     }
                 }
-            } else if type_str == "array" {
-                if let Some(items) = sch_obj.get("items") {
-                    if let Some(inst_arr) = inst.as_array() {
-                        for (idx, item) in inst_arr.iter().enumerate() {
-                            let item_path = format!("{path}[{idx}]");
-                            self.visit_instance(item, items, root_schema, &item_path, errors);
-                        }
-                    }
+            } else if type_str == "array"
+                && let Some(items) = sch_obj.get("items")
+                && let Some(inst_arr) = inst.as_array()
+            {
+                for (idx, item) in inst_arr.iter().enumerate() {
+                    let item_path = format!("{path}[{idx}]");
+                    self.visit_instance(item, items, root_schema, &item_path, errors);
                 }
             }
         }
@@ -504,15 +498,14 @@ impl XGtsRefValidator {
         }
 
         // If current is an object with x-gts-ref, resolve it
-        if let Some(obj) = current.as_object() {
-            if let Some(ref_value) = obj.get("x-gts-ref") {
-                if let Some(ref_str) = ref_value.as_str() {
-                    if ref_str.starts_with('/') {
-                        return Self::resolve_pointer(schema, ref_str);
-                    }
-                    return Some(ref_str.to_owned());
-                }
+        if let Some(obj) = current.as_object()
+            && let Some(ref_value) = obj.get("x-gts-ref")
+            && let Some(ref_str) = ref_value.as_str()
+        {
+            if ref_str.starts_with('/') {
+                return Self::resolve_pointer(schema, ref_str);
             }
+            return Some(ref_str.to_owned());
         }
 
         None


### PR DESCRIPTION
- Update Cargo.toml edition from 2021 to 2024
- Apply Rust 2024 let-chain syntax throughout codebase:
  - Replace nested if-let statements with let-chain patterns
  - Simplify conditional logic using && let syntax
- Fix import ordering and formatting:
  - Reorder imports alphabetically
  - Apply consistent formatting to multi-line statements
- Remove unnecessary intermediate variable assignments
- Apply clippy suggestions for cle

Issue https://github.com/GlobalTypeSystem/gts-rust/issues/38