### PR TITLE
Prohibit direct serialization of nested GTS structs (incl. cfg_attr)

### DIFF
--- a/gts-macros-cli/src/main.rs
+++ b/gts-macros-cli/src/main.rs
@@ -39,7 +39,7 @@ mod test_structs {
         description = "Audit event with user context",
         properties = "user_agent,user_id,ip_address,data"
     )]
-    #[derive(Debug, Serialize, Deserialize, JsonSchema)]
+    #[derive(Debug, JsonSchema)]
     pub struct AuditPayloadV1<D> {
         pub user_agent: String,
         pub user_id: uuid::Uuid,
@@ -54,7 +54,7 @@ mod test_structs {
         description = "Order placement audit event",
         properties = "order_id,product_id"
     )]
-    #[derive(Debug, Serialize, Deserialize, JsonSchema)]
+    #[derive(Debug, JsonSchema)]
     pub struct PlaceOrderDataV1<E> {
         pub order_id: uuid::Uuid,
         pub product_id: uuid::Uuid,
@@ -68,7 +68,7 @@ mod test_structs {
         description = "Order placement audit event",
         properties = "order_id"
     )]
-    #[derive(Debug, Serialize, Deserialize, JsonSchema)]
+    #[derive(Debug, JsonSchema)]
     pub struct PlaceOrderDataPayloadV1 {
         pub order_id: uuid::Uuid,
     }

--- a/gts-macros/README.md
+++ b/gts-macros/README.md
@@ -28,7 +28,7 @@ use uuid::Uuid;
 use gts::gts::{GtsInstanceId, GtsSchemaId};
 
 // Base event type (root of the hierarchy)
-// Note: #[derive(Serialize, Deserialize, JsonSchema)] is added automatically!
+// Note: Base structs get Serialize/Deserialize/JsonSchema automatically.
 #[derive(Debug)]
 #[struct_to_gts_schema(
     dir_path = "schemas",
@@ -83,11 +83,12 @@ The macro validates your annotations at compile time, catching errors early.
 ### Automatic Derives
 
 The macro automatically adds these derives to your struct:
-- `serde::Serialize`
-- `serde::Deserialize`
-- `schemars::JsonSchema`
+- **Base structs** (`base = true`): `serde::Serialize`, `serde::Deserialize`, `schemars::JsonSchema`
+- **Nested structs** (`base = ParentStruct`): `schemars::JsonSchema` only  
+  (direct Serialize/Deserialize is intentionally blocked)
 
-**Do NOT add these derives manually** - they will conflict. You can add other derives like `Debug`, `Clone`, etc.
+**Do NOT add Serialize/Deserialize manually for nested structs** - direct serialization is prohibited.  
+You can add other derives like `Debug`, `Clone`, etc.
 
 ```rust
 // ✅ Correct - only add Debug, Clone, etc.

--- a/gts-macros/tests/compile_fail/nested_direct_serialize.rs
+++ b/gts-macros/tests/compile_fail/nested_direct_serialize.rs
@@ -1,0 +1,40 @@
+//! Test: Nested structs should NOT be directly serializable
+//! This test verifies Issue #24 - nested structs can only be serialized through their base struct
+
+use gts::GtsInstanceId;
+use gts_macros::struct_to_gts_schema;
+
+// Base type with generic payload field
+#[struct_to_gts_schema(
+    dir_path = "schemas",
+    base = true,
+    schema_id = "gts.x.core.events.base.v1~",
+    description = "Base event type",
+    properties = "id,payload"
+)]
+#[derive(Debug)]
+pub struct BaseEventV1<P> {
+    pub id: GtsInstanceId,
+    pub payload: P,
+}
+
+// Nested type that extends BaseEventV1
+#[struct_to_gts_schema(
+    dir_path = "schemas",
+    base = BaseEventV1,
+    schema_id = "gts.x.core.events.base.v1~x.app.audit.event.v1~",
+    description = "Audit event with user context",
+    properties = "user_id"
+)]
+#[derive(Debug)]
+pub struct AuditEventV1 {
+    pub user_id: String,
+}
+
+fn main() {
+    // This should NOT compile: direct serialization of nested struct
+    let nested = AuditEventV1 {
+        user_id: "user1".to_string(),
+    };
+    let _ = serde_json::to_value(&nested);
+}

--- a/gts-macros/tests/compile_fail/nested_direct_serialize.stderr
+++ b/gts-macros/tests/compile_fail/nested_direct_serialize.stderr
@@ -1,0 +1,34 @@
+error[E0277]: the trait bound `AuditEventV1: serde::Serialize` is not satisfied
+  --> tests/compile_fail/nested_direct_serialize.rs:39:35
+   |
+39 |     let _ = serde_json::to_value(&nested);
+   |             --------------------  ^^^^^^ unsatisfied trait bound
+   |             |
+   |             required by a bound introduced by this call
+   |
+help: the trait `_::_serde::Serialize` is not implemented for `AuditEventV1`
+  --> tests/compile_fail/nested_direct_serialize.rs:30:1
+   |
+30 | pub struct AuditEventV1 {
+   | ^^^^^^^^^^^^^^^^^^^^^^^
+   = note: for local types consider adding `#[derive(serde::Serialize)]` to your `AuditEventV1` type
+   = note: for types from other crates check whether the crate offers a `serde` feature flag
+   = help: the following other types implement trait `_::_serde::Serialize`:
+             &'a T
+             &'a mut T
+             ()
+             (T,)
+             (T0, T1)
+             (T0, T1, T2)
+             (T0, T1, T2, T3)
+             (T0, T1, T2, T3, T4)
+           and $N others
+   = note: required for `&AuditEventV1` to implement `_::_serde::Serialize`
+note: required by a bound in `to_value`
+  --> $CARGO/serde_json-$VERSION/src/value/mod.rs
+   |
+   | pub fn to_value<T>(value: T) -> Result<Value, Error>
+   |        -------- required by a bound in this function
+   | where
+   |     T: Serialize,
+   |        ^^^^^^^^^ required by this bound in `to_value`

--- a/gts-macros/tests/compile_fail/nested_direct_serialize_cfg_attr.rs
+++ b/gts-macros/tests/compile_fail/nested_direct_serialize_cfg_attr.rs
@@ -1,0 +1,30 @@
+//! Test: Nested structs must not derive Serialize/Deserialize via cfg_attr
+
+use gts::GtsInstanceId;
+use gts_macros::struct_to_gts_schema;
+
+#[struct_to_gts_schema(
+    dir_path = "schemas",
+    base = true,
+    schema_id = "gts.x.core.events.base.v1~",
+    description = "Base event type",
+    properties = "id,payload"
+)]
+pub struct BaseEventV1<P> {
+    pub id: GtsInstanceId,
+    pub payload: P,
+}
+
+#[cfg_attr(all(), derive(serde::Serialize, serde::Deserialize))]
+#[struct_to_gts_schema(
+    dir_path = "schemas",
+    base = BaseEventV1,
+    schema_id = "gts.x.core.events.base.v1~x.app.audit.event.v1~",
+    description = "Audit event with user context",
+    properties = "user_id"
+)]
+pub struct AuditEventV1 {
+    pub user_id: String,
+}
+
+fn main() {}

--- a/gts-macros/tests/compile_fail/nested_direct_serialize_cfg_attr.stderr
+++ b/gts-macros/tests/compile_fail/nested_direct_serialize_cfg_attr.stderr
@@ -1,0 +1,67 @@
+error[E0119]: conflicting implementations of trait `GtsSerialize` for type `AuditEventV1`
+  --> tests/compile_fail/nested_direct_serialize_cfg_attr.rs:19:1
+   |
+19 | / #[struct_to_gts_schema(
+20 | |     dir_path = "schemas",
+21 | |     base = BaseEventV1,
+22 | |     schema_id = "gts.x.core.events.base.v1~x.app.audit.event.v1~",
+23 | |     description = "Audit event with user context",
+24 | |     properties = "user_id"
+25 | | )]
+   | |__^
+   |
+   = note: conflicting implementation in crate `gts`:
+           - impl<T> GtsSerialize for T
+             where T: _::_serde::Serialize;
+   = note: this error originates in the attribute macro `struct_to_gts_schema` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error[E0119]: conflicting implementations of trait `GtsDeserialize<'_>` for type `AuditEventV1`
+  --> tests/compile_fail/nested_direct_serialize_cfg_attr.rs:19:1
+   |
+19 | / #[struct_to_gts_schema(
+20 | |     dir_path = "schemas",
+21 | |     base = BaseEventV1,
+22 | |     schema_id = "gts.x.core.events.base.v1~x.app.audit.event.v1~",
+23 | |     description = "Audit event with user context",
+24 | |     properties = "user_id"
+25 | | )]
+   | |__^
+   |
+   = note: conflicting implementation in crate `gts`:
+           - impl<'de, T> GtsDeserialize<'de> for T
+             where T: _::_serde::Deserialize<'de>;
+   = note: this error originates in the attribute macro `struct_to_gts_schema` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error[E0119]: conflicting implementations of trait `GtsNoDirectSerialize` for type `AuditEventV1`
+  --> tests/compile_fail/nested_direct_serialize_cfg_attr.rs:19:1
+   |
+19 | / #[struct_to_gts_schema(
+20 | |     dir_path = "schemas",
+21 | |     base = BaseEventV1,
+22 | |     schema_id = "gts.x.core.events.base.v1~x.app.audit.event.v1~",
+23 | |     description = "Audit event with user context",
+24 | |     properties = "user_id"
+25 | | )]
+   | |__^
+   |
+   = note: conflicting implementation in crate `gts`:
+           - impl<T> GtsNoDirectSerialize for T
+             where T: _::_serde::Serialize;
+   = note: this error originates in the attribute macro `struct_to_gts_schema` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error[E0119]: conflicting implementations of trait `GtsNoDirectDeserialize` for type `AuditEventV1`
+  --> tests/compile_fail/nested_direct_serialize_cfg_attr.rs:19:1
+   |
+19 | / #[struct_to_gts_schema(
+20 | |     dir_path = "schemas",
+21 | |     base = BaseEventV1,
+22 | |     schema_id = "gts.x.core.events.base.v1~x.app.audit.event.v1~",
+23 | |     description = "Audit event with user context",
+24 | |     properties = "user_id"
+25 | | )]
+   | |__^
+   |
+   = note: conflicting implementation in crate `gts`:
+           - impl<T> GtsNoDirectDeserialize for T
+             where for<'de> T: _::_serde::Deserialize<'de>;
+   = note: this error originates in the attribute macro `struct_to_gts_schema` (in Nightly builds, run with -Z macro-backtrace for more info)

--- a/gts/src/lib.rs
+++ b/gts/src/lib.rs
@@ -14,7 +14,10 @@ pub use files_reader::GtsFileReader;
 pub use gts::{GtsError, GtsID, GtsIdSegment, GtsInstanceId, GtsSchemaId, GtsWildcard};
 pub use ops::GtsOps;
 pub use path_resolver::JsonPathResolver;
-pub use schema::{GtsSchema, strip_schema_metadata};
+pub use schema::{
+    GtsDeserialize, GtsDeserializeWrapper, GtsNoDirectDeserialize, GtsNoDirectSerialize, GtsSchema,
+    GtsSerialize, GtsSerializeWrapper, deserialize_gts, serialize_gts, strip_schema_metadata,
+};
 pub use schema_cast::{GtsEntityCastResult, SchemaCastError};
 pub use store::{GtsReader, GtsStore, GtsStoreQueryResult, StoreError};
 pub use x_gts_ref::{XGtsRefValidationError, XGtsRefValidator};


### PR DESCRIPTION
## Summary
- Block direct Serialize/Deserialize on nested GTS structs via marker traits and macro-emitted impls
- Detect cfg_attr(derive(Serialize/Deserialize)) and add compile-fail coverage
- Update macro attribute parsing and documentation around derives

Fixes #24

## Testing
- cargo test -p gts-macros
- cargo test -p gts
- cargo clippy --all-targets -- -D warnings