### PR TITLE
Implement #[gts_error] macro

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -535,6 +535,7 @@ checksum = "0cc23270f6e1808e30a928bdc84dea0b9b4136a8bc82338574f23baf47bbd280"
 name = "gts"
 version = "0.7.8"
 dependencies = [
+ "http",
  "jsonschema",
  "schemars",
  "serde",
@@ -574,6 +575,7 @@ name = "gts-macros"
 version = "0.7.8"
 dependencies = [
  "gts",
+ "http",
  "jsonschema",
  "proc-macro2",
  "quote",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -156,6 +156,9 @@ uuid = { version = "1.19", features = ["serde", "v4", "v5"] }
 # CLI dependencies
 clap = { version = "4.5", features = ["derive"] }
 
+# HTTP types
+http = "1.3"
+
 # Server dependencies
 axum = { version = "0.8", features = ["json"] }
 tokio = { version = "1.49", features = ["full"] }

--- a/gts-macros/Cargo.toml
+++ b/gts-macros/Cargo.toml
@@ -26,7 +26,9 @@ proc-macro2 = "1.0"
 serde_json.workspace = true
 
 [dev-dependencies]
+http.workspace = true
 serde.workspace = true
+serde_json.workspace = true
 trybuild = "1.0"
 jsonschema.workspace = true
 gts = { path = "../gts" }

--- a/gts-macros/tests/compile_fail/gts_error_invalid_status.rs
+++ b/gts-macros/tests/compile_fail/gts_error_invalid_status.rs
@@ -1,0 +1,12 @@
+use gts_macros::gts_error;
+
+#[gts_error(
+    r#type = "cf.system.logical.not_found.v1",
+    status = 999,
+    title = "Not Found",
+)]
+pub struct InvalidStatusError {
+    pub gts_id: String,
+}
+
+fn main() {}

--- a/gts-macros/tests/compile_fail/gts_error_invalid_status.stderr
+++ b/gts-macros/tests/compile_fail/gts_error_invalid_status.stderr
@@ -1,0 +1,5 @@
+error: gts_error: HTTP status code must be between 100 and 599
+ --> tests/compile_fail/gts_error_invalid_status.rs:5:14
+  |
+5 |     status = 999,
+  |              ^^^

--- a/gts-macros/tests/compile_fail/gts_error_missing_status.rs
+++ b/gts-macros/tests/compile_fail/gts_error_missing_status.rs
@@ -1,0 +1,11 @@
+use gts_macros::gts_error;
+
+#[gts_error(
+    r#type = "cf.system.logical.not_found.v1",
+    title = "Not Found",
+)]
+pub struct MissingStatusError {
+    pub gts_id: String,
+}
+
+fn main() {}

--- a/gts-macros/tests/compile_fail/gts_error_missing_status.stderr
+++ b/gts-macros/tests/compile_fail/gts_error_missing_status.stderr
@@ -1,0 +1,10 @@
+error: gts_error: Missing required attribute: 'status'
+ --> tests/compile_fail/gts_error_missing_status.rs:3:1
+  |
+3 | / #[gts_error(
+4 | |     r#type = "cf.system.logical.not_found.v1",
+5 | |     title = "Not Found",
+6 | | )]
+  | |__^
+  |
+  = note: this error originates in the attribute macro `gts_error` (in Nightly builds, run with -Z macro-backtrace for more info)

--- a/gts-macros/tests/compile_fail/gts_error_missing_title.rs
+++ b/gts-macros/tests/compile_fail/gts_error_missing_title.rs
@@ -1,0 +1,11 @@
+use gts_macros::gts_error;
+
+#[gts_error(
+    r#type = "cf.system.logical.not_found.v1",
+    status = 404,
+)]
+pub struct MissingTitleError {
+    pub gts_id: String,
+}
+
+fn main() {}

--- a/gts-macros/tests/compile_fail/gts_error_missing_title.stderr
+++ b/gts-macros/tests/compile_fail/gts_error_missing_title.stderr
@@ -1,0 +1,10 @@
+error: gts_error: Missing required attribute: 'title'
+ --> tests/compile_fail/gts_error_missing_title.rs:3:1
+  |
+3 | / #[gts_error(
+4 | |     r#type = "cf.system.logical.not_found.v1",
+5 | |     status = 404,
+6 | | )]
+  | |__^
+  |
+  = note: this error originates in the attribute macro `gts_error` (in Nightly builds, run with -Z macro-backtrace for more info)

--- a/gts-macros/tests/compile_fail/gts_error_missing_type.rs
+++ b/gts-macros/tests/compile_fail/gts_error_missing_type.rs
@@ -1,0 +1,11 @@
+use gts_macros::gts_error;
+
+#[gts_error(
+    status = 404,
+    title = "Not Found",
+)]
+pub struct MissingTypeError {
+    pub gts_id: String,
+}
+
+fn main() {}

--- a/gts-macros/tests/compile_fail/gts_error_missing_type.stderr
+++ b/gts-macros/tests/compile_fail/gts_error_missing_type.stderr
@@ -1,0 +1,10 @@
+error: gts_error: Missing required attribute: 'type'
+ --> tests/compile_fail/gts_error_missing_type.rs:3:1
+  |
+3 | / #[gts_error(
+4 | |     status = 404,
+5 | |     title = "Not Found",
+6 | | )]
+  | |__^
+  |
+  = note: this error originates in the attribute macro `gts_error` (in Nightly builds, run with -Z macro-backtrace for more info)

--- a/gts-macros/tests/compile_fail/gts_error_on_enum.rs
+++ b/gts-macros/tests/compile_fail/gts_error_on_enum.rs
@@ -1,0 +1,13 @@
+use gts_macros::gts_error;
+
+#[gts_error(
+    r#type = "cf.system.logical.not_found.v1",
+    status = 404,
+    title = "Not Found",
+)]
+pub enum NotAStructError {
+    Variant1,
+    Variant2,
+}
+
+fn main() {}

--- a/gts-macros/tests/compile_fail/gts_error_on_enum.stderr
+++ b/gts-macros/tests/compile_fail/gts_error_on_enum.stderr
@@ -1,0 +1,5 @@
+error: gts_error: Only structs are supported, not enums.
+ --> tests/compile_fail/gts_error_on_enum.rs:8:10
+  |
+8 | pub enum NotAStructError {
+  |          ^^^^^^^^^^^^^^^

--- a/gts-macros/tests/compile_fail/gts_error_tuple_struct.rs
+++ b/gts-macros/tests/compile_fail/gts_error_tuple_struct.rs
@@ -1,0 +1,10 @@
+use gts_macros::gts_error;
+
+#[gts_error(
+    r#type = "cf.system.logical.not_found.v1",
+    status = 404,
+    title = "Not Found",
+)]
+pub struct TupleStructError(String, u32);
+
+fn main() {}

--- a/gts-macros/tests/compile_fail/gts_error_tuple_struct.stderr
+++ b/gts-macros/tests/compile_fail/gts_error_tuple_struct.stderr
@@ -1,0 +1,5 @@
+error: gts_error: Tuple structs are not supported. Use a struct with named fields.
+ --> tests/compile_fail/gts_error_tuple_struct.rs:8:12
+  |
+8 | pub struct TupleStructError(String, u32);
+  |            ^^^^^^^^^^^^^^^^

--- a/gts-macros/tests/gts_error_tests.rs
+++ b/gts-macros/tests/gts_error_tests.rs
@@ -1,0 +1,447 @@
+#![allow(clippy::unwrap_used, clippy::expect_used)]
+
+use gts::GtsError;
+use gts_macros::gts_error;
+use serde::Serialize;
+
+// ---------------------------------------------------------------------------
+// Test error structs
+// ---------------------------------------------------------------------------
+
+// Root error (no base)
+#[gts_error(r#type = "gts.cf.core.errors.err.v1", status = 500, title = "Error")]
+pub struct BaseError;
+
+// Child errors (chained from BaseError)
+
+#[gts_error(
+    r#type = "cf.system.logical.not_found.v1",
+    base = BaseError,
+    status = 404,
+    title = "Not Found",
+)]
+pub struct EntityNotFoundError {
+    pub gts_id: String,
+}
+
+#[gts_error(
+    r#type = "cf.system.logical.validation_failed.v1",
+    base = BaseError,
+    status = 422,
+    title = "Validation Failed",
+)]
+pub struct ValidationFailedError {
+    #[gts_error(as_errors)]
+    pub violations: Vec<String>,
+    pub entity_type: String,
+}
+
+#[gts_error(
+    r#type = "cf.system.transport.connection_refused.v1",
+    base = BaseError,
+    status = 503,
+    title = "Connection Refused",
+)]
+pub struct ConnectionRefusedError {
+    pub target_host: String,
+    #[gts_error(skip_metadata)]
+    pub internal_trace: String,
+}
+
+#[gts_error(
+    r#type = "cf.system.http.internal_server_error.v1",
+    base = BaseError,
+    status = 500,
+    title = "Internal Server Error",
+)]
+pub struct InternalServerErrorType {
+    #[gts_error(skip_metadata)]
+    pub cause: String,
+}
+
+#[gts_error(
+    r#type = "cf.system.http.rate_limited.v1",
+    base = BaseError,
+    status = 429,
+    title = "Rate Limited",
+)]
+pub struct RateLimitedError {
+    pub retry_after: u64,
+}
+
+#[gts_error(
+    r#type = "cf.system.logical.conflict.v1",
+    base = BaseError,
+    status = 409,
+    title = "Conflict",
+)]
+pub struct ConflictError {
+    #[gts_error(skip_metadata)]
+    pub debug_info: String,
+    #[gts_error(skip_metadata)]
+    pub stack_trace: String,
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub struct FieldViolation {
+    pub field: String,
+    pub message: String,
+}
+
+#[gts_error(
+    r#type = "cf.system.logical.validation_failed_rich.v1",
+    base = BaseError,
+    status = 422,
+    title = "Validation Failed",
+)]
+pub struct RichValidationError {
+    #[gts_error(as_errors)]
+    pub violations: Vec<FieldViolation>,
+    pub entity_type: String,
+    #[gts_error(skip_metadata)]
+    pub raw_input: String,
+}
+
+// Unit struct without base (another root error)
+#[gts_error(
+    r#type = "gts.cf.core.errors.unit.v1",
+    status = 500,
+    title = "Unit Error"
+)]
+pub struct UnitRootError;
+
+// ---------------------------------------------------------------------------
+// Constants tests
+// ---------------------------------------------------------------------------
+
+#[test]
+fn test_root_error_gts_id() {
+    assert_eq!(BaseError::gts_id(), "gts://gts.cf.core.errors.err.v1~");
+}
+
+#[test]
+fn test_child_error_gts_id() {
+    assert_eq!(
+        EntityNotFoundError::gts_id(),
+        "gts://gts.cf.core.errors.err.v1~cf.system.logical.not_found.v1~"
+    );
+}
+
+#[test]
+fn test_gts_id_starts_with_gts_uri_prefix() {
+    assert!(BaseError::gts_id().starts_with("gts://"));
+    assert!(EntityNotFoundError::gts_id().starts_with("gts://"));
+    assert!(ValidationFailedError::gts_id().starts_with("gts://"));
+    assert!(ConnectionRefusedError::gts_id().starts_with("gts://"));
+    assert!(InternalServerErrorType::gts_id().starts_with("gts://"));
+}
+
+#[test]
+fn test_gts_id_ends_with_tilde() {
+    assert!(BaseError::gts_id().ends_with('~'));
+    assert!(EntityNotFoundError::gts_id().ends_with('~'));
+    assert!(ValidationFailedError::gts_id().ends_with('~'));
+    assert!(InternalServerErrorType::gts_id().ends_with('~'));
+}
+
+#[test]
+fn test_gts_id_contains_base_segment() {
+    assert!(EntityNotFoundError::gts_id().contains("gts.cf.core.errors.err.v1~"));
+    assert!(ValidationFailedError::gts_id().contains("gts.cf.core.errors.err.v1~"));
+}
+
+#[test]
+fn test_root_error_single_segment() {
+    let id = BaseError::gts_id();
+    let without_prefix = id.strip_prefix("gts://").unwrap();
+    let without_trailing = without_prefix.strip_suffix('~').unwrap();
+    let segments: Vec<&str> = without_trailing.split('~').collect();
+    assert_eq!(
+        segments.len(),
+        1,
+        "Root error should have 1 segment, got: {segments:?}"
+    );
+}
+
+#[test]
+fn test_child_error_two_segment_chain() {
+    let id = EntityNotFoundError::gts_id();
+    let without_prefix = id.strip_prefix("gts://").unwrap();
+    let without_trailing = without_prefix.strip_suffix('~').unwrap();
+    let segments: Vec<&str> = without_trailing.split('~').collect();
+    assert_eq!(
+        segments.len(),
+        2,
+        "Child error should have 2-segment chain, got: {segments:?}"
+    );
+}
+
+#[test]
+fn test_status_method() {
+    assert_eq!(EntityNotFoundError::status(), http::StatusCode::NOT_FOUND);
+    assert_eq!(
+        ValidationFailedError::status(),
+        http::StatusCode::UNPROCESSABLE_ENTITY
+    );
+    assert_eq!(
+        ConnectionRefusedError::status(),
+        http::StatusCode::SERVICE_UNAVAILABLE
+    );
+    assert_eq!(
+        InternalServerErrorType::status(),
+        http::StatusCode::INTERNAL_SERVER_ERROR
+    );
+    assert_eq!(
+        RateLimitedError::status(),
+        http::StatusCode::TOO_MANY_REQUESTS
+    );
+    assert_eq!(ConflictError::status(), http::StatusCode::CONFLICT);
+}
+
+#[test]
+fn test_title_constant() {
+    assert_eq!(EntityNotFoundError::TITLE, "Not Found");
+    assert_eq!(ValidationFailedError::TITLE, "Validation Failed");
+    assert_eq!(ConnectionRefusedError::TITLE, "Connection Refused");
+    assert_eq!(InternalServerErrorType::TITLE, "Internal Server Error");
+    assert_eq!(RateLimitedError::TITLE, "Rate Limited");
+}
+
+// ---------------------------------------------------------------------------
+// GtsError trait tests
+// ---------------------------------------------------------------------------
+
+#[test]
+fn test_trait_gts_id_matches_method() {
+    assert_eq!(
+        <EntityNotFoundError as GtsError>::gts_id(),
+        EntityNotFoundError::gts_id()
+    );
+}
+
+#[test]
+fn test_trait_status_matches_method() {
+    assert_eq!(
+        <EntityNotFoundError as GtsError>::status(),
+        EntityNotFoundError::status()
+    );
+}
+
+#[test]
+fn test_trait_title_matches_constant() {
+    assert_eq!(
+        <EntityNotFoundError as GtsError>::TITLE,
+        EntityNotFoundError::TITLE
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Display trait tests
+// ---------------------------------------------------------------------------
+
+#[test]
+fn test_display_format() {
+    let err = EntityNotFoundError {
+        gts_id: "some-entity-123".to_owned(),
+    };
+    let display = format!("{err}");
+    assert_eq!(
+        display,
+        "Not Found: gts://gts.cf.core.errors.err.v1~cf.system.logical.not_found.v1~"
+    );
+}
+
+#[test]
+fn test_display_root_error() {
+    let err = BaseError;
+    let display = format!("{err}");
+    assert_eq!(display, "Error: gts://gts.cf.core.errors.err.v1~");
+}
+
+#[test]
+fn test_display_unit_root_error() {
+    let err = UnitRootError;
+    let display = format!("{err}");
+    assert_eq!(display, "Unit Error: gts://gts.cf.core.errors.unit.v1~");
+}
+
+// ---------------------------------------------------------------------------
+// std::error::Error trait tests
+// ---------------------------------------------------------------------------
+
+#[test]
+fn test_implements_error_trait() {
+    let err = EntityNotFoundError {
+        gts_id: "test".to_owned(),
+    };
+    // Verify it can be used as a &dyn std::error::Error
+    let dyn_err: &dyn std::error::Error = &err;
+    assert!(dyn_err.to_string().contains("Not Found"));
+}
+
+#[test]
+fn test_implements_error_trait_unit_struct() {
+    let err = BaseError;
+    let dyn_err: &dyn std::error::Error = &err;
+    assert!(dyn_err.to_string().contains("Error"));
+}
+
+// ---------------------------------------------------------------------------
+// Metadata tests
+// ---------------------------------------------------------------------------
+
+#[test]
+fn test_metadata_basic_field() {
+    let err = EntityNotFoundError {
+        gts_id: "entity-42".to_owned(),
+    };
+    let metadata = err.error_metadata().expect("should have metadata");
+    assert_eq!(metadata.len(), 1);
+    assert_eq!(metadata.get("gts_id").unwrap(), "entity-42");
+}
+
+#[test]
+fn test_metadata_multiple_fields() {
+    let err = RateLimitedError { retry_after: 30 };
+    let metadata = err.error_metadata().expect("should have metadata");
+    assert_eq!(metadata.len(), 1);
+    assert_eq!(metadata.get("retry_after").unwrap(), 30);
+}
+
+#[test]
+fn test_metadata_skip_metadata() {
+    let err = ConnectionRefusedError {
+        target_host: "db.example.com".to_owned(),
+        internal_trace: "sensitive-stack-trace".to_owned(),
+    };
+    let metadata = err.error_metadata().expect("should have metadata");
+    assert_eq!(metadata.len(), 1);
+    assert!(metadata.contains_key("target_host"));
+    assert!(
+        !metadata.contains_key("internal_trace"),
+        "skip_metadata field should be excluded"
+    );
+}
+
+#[test]
+fn test_metadata_as_errors() {
+    let err = ValidationFailedError {
+        violations: vec![
+            "field 'name' is required".to_owned(),
+            "field 'email' is invalid".to_owned(),
+        ],
+        entity_type: "User".to_owned(),
+    };
+    let metadata = err.error_metadata().expect("should have metadata");
+    assert_eq!(metadata.len(), 2);
+    assert!(
+        metadata.contains_key("errors"),
+        "as_errors field should be under 'errors' key"
+    );
+    assert!(metadata.contains_key("entity_type"));
+
+    let errors = metadata.get("errors").unwrap().as_array().unwrap();
+    assert_eq!(errors.len(), 2);
+    assert_eq!(errors[0], "field 'name' is required");
+}
+
+#[test]
+fn test_metadata_as_errors_with_complex_type() {
+    let err = RichValidationError {
+        violations: vec![FieldViolation {
+            field: "email".to_owned(),
+            message: "invalid format".to_owned(),
+        }],
+        entity_type: "User".to_owned(),
+        raw_input: "should-be-excluded".to_owned(),
+    };
+    let metadata = err.error_metadata().expect("should have metadata");
+    assert_eq!(metadata.len(), 2);
+    assert!(metadata.contains_key("errors"));
+    assert!(metadata.contains_key("entity_type"));
+    assert!(
+        !metadata.contains_key("raw_input"),
+        "skip_metadata field should be excluded"
+    );
+
+    let errors = metadata.get("errors").unwrap().as_array().unwrap();
+    assert_eq!(errors.len(), 1);
+    assert_eq!(errors[0]["field"], "email");
+    assert_eq!(errors[0]["message"], "invalid format");
+}
+
+#[test]
+fn test_metadata_unit_struct_returns_none() {
+    let err = BaseError;
+    assert!(err.error_metadata().is_none());
+}
+
+#[test]
+fn test_metadata_child_with_all_skipped_returns_none() {
+    let err = InternalServerErrorType {
+        cause: "something".to_owned(),
+    };
+    assert!(
+        err.error_metadata().is_none(),
+        "all fields are skip_metadata, should return None"
+    );
+}
+
+#[test]
+fn test_metadata_all_fields_skipped_returns_none() {
+    let err = ConflictError {
+        debug_info: "some debug".to_owned(),
+        stack_trace: "some trace".to_owned(),
+    };
+    assert!(
+        err.error_metadata().is_none(),
+        "all fields are skip_metadata, should return None"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Debug / Clone derive tests
+// ---------------------------------------------------------------------------
+
+#[test]
+fn test_debug_is_derived() {
+    let err = EntityNotFoundError {
+        gts_id: "test".to_owned(),
+    };
+    let debug = format!("{err:?}");
+    assert!(debug.contains("EntityNotFoundError"));
+    assert!(debug.contains("test"));
+}
+
+#[test]
+fn test_clone_is_derived() {
+    let err = EntityNotFoundError {
+        gts_id: "test".to_owned(),
+    };
+    let cloned = err.clone();
+    assert_eq!(
+        cloned.error_metadata().unwrap().get("gts_id"),
+        err.error_metadata().unwrap().get("gts_id")
+    );
+}
+
+// ---------------------------------------------------------------------------
+// StatusCode tests
+// ---------------------------------------------------------------------------
+
+#[test]
+fn test_status_as_u16() {
+    assert_eq!(EntityNotFoundError::status().as_u16(), 404);
+    assert_eq!(BaseError::status().as_u16(), 500);
+    assert_eq!(RateLimitedError::status().as_u16(), 429);
+}
+
+// ---------------------------------------------------------------------------
+// Compile-fail tests
+// ---------------------------------------------------------------------------
+
+#[test]
+fn test_compile_fail() {
+    let t = trybuild::TestCases::new();
+    t.compile_fail("tests/compile_fail/gts_error_*.rs");
+}

--- a/gts/Cargo.toml
+++ b/gts/Cargo.toml
@@ -16,6 +16,7 @@ publish = true
 workspace = true
 
 [dependencies]
+http.workspace = true
 serde.workspace = true
 serde_json.workspace = true
 thiserror.workspace = true

--- a/gts/src/error_type.rs
+++ b/gts/src/error_type.rs
@@ -1,0 +1,72 @@
+//! GTS error type trait for compile-time error definitions.
+//!
+//! This module provides the `GtsError` trait which enables compile-time
+//! error type definitions using the `#[gts_error]` proc macro. Error types
+//! are classified using GTS identifiers following the two-segment chain model.
+//!
+//! # Example
+//!
+//! ```ignore
+//! use gts::GtsError;
+//!
+//! #[gts_error(
+//!     r#type = "gts.cf.core.errors.err.v1",
+//!     status = 500,
+//!     title = "Error",
+//! )]
+//! pub struct BaseError;
+//!
+//! #[gts_error(
+//!     r#type = "cf.types_registry.entity.not_found.v1",
+//!     base = BaseError,
+//!     status = 404,
+//!     title = "Entity Not Found",
+//! )]
+//! pub struct EntityNotFoundError { pub gts_id: String }
+//!
+//! assert_eq!(BaseError::gts_id(), "gts://gts.cf.core.errors.err.v1~");
+//! assert_eq!(EntityNotFoundError::gts_id(), "gts://gts.cf.core.errors.err.v1~cf.types_registry.entity.not_found.v1~");
+//! assert_eq!(EntityNotFoundError::STATUS, 404);
+//! assert_eq!(EntityNotFoundError::TITLE, "Entity Not Found");
+//! ```
+
+use std::collections::HashMap;
+
+/// Trait for types that represent a GTS error type definition.
+///
+/// This trait is automatically implemented by the `#[gts_error]` proc macro.
+/// It provides the error's GTS identity, HTTP status, title, and a method
+/// to extract sanitized metadata from struct fields.
+///
+/// Consuming crates (e.g., `modkit-errors`) can use this trait to build
+/// RFC 9457 Problem Details responses and error registration metadata.
+pub trait GtsError: std::fmt::Display + std::fmt::Debug {
+    /// Full GTS type URI for this error.
+    ///
+    /// For root errors: `gts://{type}~`
+    /// For child errors: `gts://{base_chain}{type}~`
+    ///
+    /// Example: `gts://gts.cf.core.errors.err.v1~cf.system.logical.not_found.v1~`
+    #[must_use]
+    fn gts_id() -> &'static str;
+
+    /// HTTP status code for this error type.
+    ///
+    /// The value is guaranteed to be valid because the `#[gts_error]` macro
+    /// validates the status code at compile time (100–599).
+    #[must_use]
+    fn status() -> http::StatusCode;
+
+    /// Static human-readable title for this error type.
+    const TITLE: &'static str;
+
+    /// Collect sanitized metadata from struct fields.
+    ///
+    /// Fields annotated with `#[gts_error(skip_metadata)]` are excluded.
+    /// Fields annotated with `#[gts_error(as_errors)]` are placed under the `"errors"` key.
+    /// All other fields are serialized as key-value pairs.
+    ///
+    /// Returns `None` if the struct has no metadata-eligible fields.
+    #[must_use]
+    fn error_metadata(&self) -> Option<HashMap<String, serde_json::Value>>;
+}

--- a/gts/src/lib.rs
+++ b/gts/src/lib.rs
@@ -1,4 +1,5 @@
 pub mod entities;
+pub mod error_type;
 pub mod files_reader;
 pub mod gts;
 pub mod ops;
@@ -10,8 +11,9 @@ pub mod x_gts_ref;
 
 // Re-export commonly used types
 pub use entities::{GtsConfig, GtsEntity, GtsFile, ValidationError, ValidationResult};
+pub use error_type::GtsError;
 pub use files_reader::GtsFileReader;
-pub use gts::{GtsError, GtsID, GtsIdSegment, GtsInstanceId, GtsSchemaId, GtsWildcard};
+pub use gts::{GtsID, GtsIdError, GtsIdSegment, GtsInstanceId, GtsSchemaId, GtsWildcard};
 pub use ops::GtsOps;
 pub use path_resolver::JsonPathResolver;
 pub use schema::{GtsSchema, strip_schema_metadata};


### PR DESCRIPTION
- implement the `#[gts_error]` macro to validate error metadata at compile time (type/status/title/base)
- generate consistent `GTS_ID`, status helper, metadata, and trait impls for annotated structs
- add unit/compile-fail tests under `gts-macros/tests` to exercise the macro’s behaviors (gts_id chain, metadata flags, error traits)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Introduced `#[gts_error]` macro for declaring structured error types with built-in support for GTS identifiers, HTTP status codes, titles, and metadata extraction.
  * Added `GtsError` trait enabling error types to expose standardized identifiers, status codes, and contextual metadata.

* **Chores**
  * Added HTTP crate dependency for status code support.
  * Renamed core error type for naming clarity with new macro.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->