### PR TITLE
build: fix `cargo deny` checks and replace unmaintained `atty` crate

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -160,9 +160,9 @@ jobs:
 
       # Install tools via prebuilt binaries for speed.
       - name: Install cargo-deny
-        uses: taiki-e/install-action@30eab0fabba9ea3f522099957e668b21876aa39e # v2.66.6
+        uses: taiki-e/install-action@385db9cc6bf65d19775b02084a4b698eaca9a4f2 # v2
         with:
-          tool: cargo-deny
+          tool: cargo-deny@0.19.0
 
       # Run deny checks but do not fail CI (as requested).
       - name: cargo deny check
@@ -218,7 +218,7 @@ jobs:
           fi
 
       - name: Install cargo-llvm-cov
-        uses: taiki-e/install-action@30eab0fabba9ea3f522099957e668b21876aa39e # v2.66.6
+        uses: taiki-e/install-action@385db9cc6bf65d19775b02084a4b698eaca9a4f2 # v2
         with:
           tool: cargo-llvm-cov
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -123,9 +123,9 @@ jobs:
           echo "rust-version=${RUST_VER}" >> "$GITHUB_OUTPUT"
 
       - name: Install cargo-deny
-        uses: taiki-e/install-action@30eab0fabba9ea3f522099957e668b21876aa39e # v2.66.6
+        uses: taiki-e/install-action@385db9cc6bf65d19775b02084a4b698eaca9a4f2 # v2
         with:
-          tool: cargo-deny@0.16.1   # pin version; update intentionally
+          tool: cargo-deny@0.19.0   # pin version; update intentionally
 
       - name: Assert deny.toml policy file exists
         shell: bash
@@ -197,7 +197,7 @@ jobs:
       # Install cross for ARM Linux cross-compilation
       - name: Install cross
         if: matrix.cross == true
-        uses: taiki-e/install-action@30eab0fabba9ea3f522099957e668b21876aa39e # v2.66.6
+        uses: taiki-e/install-action@385db9cc6bf65d19775b02084a4b698eaca9a4f2 # v2
         with:
           tool: cross@0.2.5   # pin version; update intentionally
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -109,17 +109,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1505bd5d3d116872e7271a6d4e16d81d0c8570876c8de68093a09ac269d8aac0"
 
 [[package]]
-name = "atty"
-version = "0.2.14"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d9b39be18770d11421cdb1b9947a45dd3f37e93092cbf377614828a319d5fee8"
-dependencies = [
- "hermit-abi",
- "libc",
- "winapi",
-]
-
-[[package]]
 name = "autocfg"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -224,9 +213,9 @@ checksum = "175812e0be2bccb6abe50bb8d566126198344f707e304f45c648fd8f2cc0365e"
 
 [[package]]
 name = "bytes"
-version = "1.10.1"
+version = "1.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d71b6127be86fdcfddb610f7182ac57211d4b18a3e9c82eb2d17662f2227ad6a"
+checksum = "1e748733b7cbc798e1434b6ac524f0c1ff2ab456fe201501e6497c8417a4fc33"
 
 [[package]]
 name = "cc"
@@ -554,7 +543,6 @@ name = "gts-cli"
 version = "0.8.4"
 dependencies = [
  "anyhow",
- "atty",
  "axum",
  "chrono",
  "clap",
@@ -659,15 +647,6 @@ name = "heck"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
-
-[[package]]
-name = "hermit-abi"
-version = "0.1.19"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "62b467343b94ba476dcb2500d242dadbb39557df889310ac77c5d99100aaac33"
-dependencies = [
- "libc",
-]
 
 [[package]]
 name = "http"
@@ -1956,22 +1935,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "winapi"
-version = "0.3.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5c839a674fcd7a98952e593242ea400abe93992746761e38641405d28b00f419"
-dependencies = [
- "winapi-i686-pc-windows-gnu",
- "winapi-x86_64-pc-windows-gnu",
-]
-
-[[package]]
-name = "winapi-i686-pc-windows-gnu"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
-
-[[package]]
 name = "winapi-util"
 version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1979,12 +1942,6 @@ checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
  "windows-sys 0.61.2",
 ]
-
-[[package]]
-name = "winapi-x86_64-pc-windows-gnu"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
 name = "windows-core"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,14 @@ categories = ["development-tools::build-utils"]
 readme = "README.md"
 
 [workspace]
-members = ["gts", "gts-cli", "gts-id", "gts-macros", "gts-macros-cli", "gts-validator"]
+members = [
+    "gts",
+    "gts-cli",
+    "gts-id",
+    "gts-macros",
+    "gts-macros-cli",
+    "gts-validator",
+]
 resolver = "2"
 
 [workspace.lints.rust]
@@ -165,7 +172,7 @@ tower = "0.5"
 tower-http = { version = "0.6", features = ["trace", "cors"] }
 tracing = "0.1"
 tracing-subscriber = { version = "0.3", features = ["env-filter"] }
-atty = "0.2"
+
 chrono = "0.4"
 
 # JSON Schema validation

--- a/Makefile
+++ b/Makefile
@@ -27,7 +27,7 @@ generate-schemas: build
 	./target/release/gts generate-from-rust --source .
 
 # Run all checks and build
-all: check build generate-schemas
+all: check deny build generate-schemas
 
 # Check code formatting
 fmt:

--- a/gts-cli/Cargo.toml
+++ b/gts-cli/Cargo.toml
@@ -29,7 +29,6 @@ axum.workspace = true
 tokio.workspace = true
 tracing.workspace = true
 tracing-subscriber.workspace = true
-atty.workspace = true
 chrono.workspace = true
 regex.workspace = true
 walkdir.workspace = true

--- a/gts-cli/src/logging.rs
+++ b/gts-cli/src/logging.rs
@@ -18,7 +18,8 @@ struct Colors {
 impl Colors {
     fn new() -> Self {
         // Check if stderr is a TTY (terminal)
-        let use_colors = atty::is(atty::Stream::Stderr);
+        use std::io::IsTerminal;
+        let use_colors = std::io::stderr().is_terminal();
 
         if use_colors {
             Self {


### PR DESCRIPTION
This commit addresses issues that caused `cargo deny check` to fail:

- **Update `cargo-deny` in CI**: Bumped `taiki-e/install-action` to `v2` and `cargo-deny` to `0.19.0` in GitHub Actions workflows to properly support Rust 2024 edition parsing.
- **Resolve `bytes` Security Advisory**: Updated the `bytes` crate to `1.11.1` to resolve a security vulnerability (RUSTSEC-2024-0375 / GHSA-434x-w66g-qw3r).
- **Replace `atty` Crate**: Removed the unmaintained `atty` crate from the workspace and replaced its usage in [gts-cli/src/logging.rs](cci:7://file:///Users/alexa/git/github/gts-rust/gts-cli/src/logging.rs:0:0-0:0) with the standard library's `std::io::IsTerminal` trait.
- **Update Makefile**: Added the `deny` target to the [all](cci:1://file:///Users/alexa/git/github/gts-rust/gts-cli/src/logging.rs:275:4-315:5) build target in the Makefile to ensure license and security advisories are checked locally during full builds.
- **Format workspace**: Cargo formatted the workspace `Cargo.toml`.