### PR TITLE
feat: support x-gts-final and x-gts-abstract schema modifiers

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,4 @@ logs
 #  option (not recommended) you can uncomment the following to ignore the entire idea folder.
 .idea/
 .vscode/
+e2e.log

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,58 @@
+# CLAUDE.md
+
+Guidance for Claude Code when working in this repository.
+
+## Project Overview
+
+`gts-rust` is the Rust reference implementation of [GTS](https://github.com/GlobalTypeSystem/gts-spec) — library (`gts/`), CLI and HTTP server (`gts-cli/`, binary name `gts`), plus supporting crates (`gts-id`, `gts-macros`, `gts-macros-cli`, `gts-validator`). The server answers the REST API exercised by the shared gts-spec conformance suite.
+
+`.gts-spec/` is the spec vendored as a git submodule; `tests/` inside it is the conformance suite. See `README.md` for API/CLI details and `make help` for all targets.
+
+## Running the gts-spec Test Suite
+
+The short form is `make e2e PORT=8001` (PORT defaults to 8000; override if busy — the target fails fast if the port is already in use). It bootstraps the venv, rebuilds, starts the server, runs pytest, and shuts everything down.
+
+### Raise the file-descriptor limit (macOS)
+
+`httprunner` creates a `requests.Session` per test class and never closes it, so a keep-alive socket leaks per class until pytest exits. With ~250 test classes today, the suite blows past macOS's default 256 soft cap (`ulimit -n`) and fails mid-run with `EMFILE: Too many open files`. Raise the limit in your shell — once, for the whole session:
+
+```bash
+ulimit -n 4096
+```
+
+Persist it by adding the same line to `~/.zshrc` (or `~/.bashrc`). Required for both `make e2e` and any direct `pytest` invocation against the spec suite.
+
+### Bootstrap the venv (first time only)
+
+Tests depend on `httprunner`. Installed into `.gts-spec/.venv/` (gitignored by the submodule).
+
+```bash
+make e2e-venv                     # uses python3 by default
+make e2e-venv PYTHON=python3.11   # Python 3.11 is the safest (httprunner still pins pydantic<2)
+```
+
+### Run pytest manually against a running server
+
+Useful when iterating on a single test without the full `make e2e` cycle.
+
+```bash
+cargo build --workspace --release
+./target/release/gts server --port 8001 &
+
+PYTEST=".gts-spec/.venv/bin/python -m pytest"
+
+# Whole suite
+$PYTEST .gts-spec/tests --gts-base-url http://127.0.0.1:8001
+
+# One file / one class
+$PYTEST .gts-spec/tests/test_refimpl_x_gts_final_abstract.py --gts-base-url http://127.0.0.1:8001
+$PYTEST .gts-spec/tests/test_op12_schema_vs_schema_validation.py::TestCaseOp12_FinalBase_RejectDerived --gts-base-url http://127.0.0.1:8001
+```
+
+`GTS_BASE_URL` env var works too. The server holds state in memory with no reset endpoint — restart between full-suite runs.
+
+## Working in This Repo
+
+- `.gts-spec` is a submodule. Bump with `make update-spec`, then rerun `make e2e` to pick up new spec tests.
+- Handlers in `gts-cli/src/server.rs` stay thin — logic goes in `gts/` where it is unit-testable. New REST behavior usually already has coverage in `.gts-spec/tests/`; run the relevant file before and after to confirm.
+- `make check` is the full local gate: fmt + clippy + test + e2e.

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,14 @@
 CI := 1
 
-.PHONY: help build dev-fmt dev-clippy all check fmt clippy test deny security update-spec e2e generate-schemas
+.PHONY: help build dev-fmt dev-clippy all check fmt clippy test deny security update-spec e2e-venv e2e generate-schemas
+
+# Python interpreter used to bootstrap the venv; override with `make e2e PYTHON=python3.11`
+PYTHON ?= python3
+VENV_DIR := .gts-spec/.venv
+VENV_PY  := $(VENV_DIR)/bin/python
+
+# Port for the reference server during `make e2e`; override with `make e2e PORT=8001`
+PORT ?= 8000
 
 # Default target - show help
 .DEFAULT_GOAL := help
@@ -59,17 +67,29 @@ coverage:
 update-spec:
 	git submodule update --init --remote .gts-spec
 
-# Run end-to-end tests against gts-spec
-e2e: build
-	@echo "Starting server in background..."
-	@./target/release/gts server --port 8000 & echo $$! > .server.pid
-	@sleep 2
-	@echo "Running e2e tests..."
-	@PYTHONDONTWRITEBYTECODE=1 pytest -p no:cacheprovider --log-file=e2e.log ./.gts-spec/tests || (kill `cat .server.pid` 2>/dev/null; rm -f .server.pid; exit 1)
-	@echo "Stopping server..."
-	@kill `cat .server.pid` 2>/dev/null || true
-	@rm -f .server.pid
-	@echo "E2E tests completed successfully"
+# Create/refresh the Python venv used by the gts-spec e2e test suite
+e2e-venv: $(VENV_PY)
+
+$(VENV_PY):
+	@if [ ! -x "$(VENV_PY)" ]; then \
+		echo "Creating venv at $(VENV_DIR) using $(PYTHON)..."; \
+		$(PYTHON) -m venv $(VENV_DIR); \
+	fi
+	@echo "Installing gts-spec e2e test dependencies..."
+	@$(VENV_PY) -m pip install --quiet --upgrade pip setuptools wheel
+	@$(VENV_PY) -m pip install --quiet httprunner
+
+# Run end-to-end tests against gts-spec.
+e2e: build e2e-venv
+	@rm -rf logs e2e.log
+	@set -e; \
+	trap 'kill `cat .server.pid 2>/dev/null` 2>/dev/null || true; rm -f .server.pid' INT TERM EXIT; \
+	echo "Starting server in background on port $(PORT)..."; \
+	./target/release/gts server --port $(PORT) & echo $$! > .server.pid; \
+	sleep 2; \
+	echo "Running e2e tests..."; \
+	PYTHONDONTWRITEBYTECODE=1 $(VENV_PY) -m pytest -p no:cacheprovider --log-file=e2e.log --gts-base-url http://127.0.0.1:$(PORT) ./.gts-spec/tests; \
+	echo "E2E tests completed successfully"
 
 # Run all quality checks
 check: fmt clippy test e2e

--- a/README.md
+++ b/README.md
@@ -936,6 +936,26 @@ Run with verbose output:
 cargo test -- --nocapture
 ```
 
+### End-to-end tests against gts-spec
+
+`make e2e` runs the conformance suite from the `.gts-spec/` submodule against
+a freshly built server. On first run, bootstrap the Python venv:
+
+```bash
+make e2e-venv PYTHON=python3.11   # 3.11 is safest — httprunner pins pydantic<2
+make e2e
+```
+
+**macOS:** raise the file-descriptor limit before running, otherwise the suite
+will fail mid-run with `EMFILE: Too many open files`. `httprunner` creates a
+`requests.Session` per test class and never closes it, so a keep-alive socket
+leaks per class until pytest exits. With ~250 test classes today, this blows
+past macOS's default 256 soft cap.
+
+```bash
+ulimit -n 4096
+```
+
 ## Development
 
 ### Build

--- a/gts/src/lib.rs
+++ b/gts/src/lib.rs
@@ -6,6 +6,7 @@ pub mod path_resolver;
 pub mod schema;
 pub mod schema_cast;
 pub mod schema_compat;
+pub mod schema_modifiers;
 pub mod schema_traits;
 pub mod store;
 pub mod x_gts_ref;

--- a/gts/src/ops.rs
+++ b/gts/src/ops.rs
@@ -320,6 +320,20 @@ impl GtsOps {
             };
         }
 
+        // Validate schema modifiers (x-gts-final, x-gts-abstract): types,
+        // mutual exclusion, and that they appear only at the schema top level.
+        if entity.is_schema
+            && let Err(e) = crate::schema_modifiers::validate_schema_modifiers(&entity.content)
+        {
+            return GtsAddEntityResult {
+                ok: false,
+                id: String::new(),
+                schema_id: None,
+                is_schema: true,
+                error: e,
+            };
+        }
+
         // Always validate schemas
         if entity.is_schema
             && let Err(e) = self.store.validate_schema(&entity_id)
@@ -336,21 +350,60 @@ impl GtsOps {
             };
         }
 
-        // If validation is requested, validate the instance as well
-        if validate
-            && !entity.is_schema
-            && let Err(e) = self.store.validate_instance(&entity_id)
-        {
-            return GtsAddEntityResult {
-                ok: false,
-                id: String::new(),
-                schema_id: None,
-                is_schema: false,
-                error: format!(
-                    "Instance validation failed: {e}\n{}",
-                    self.get_details(&entity)
-                ),
-            };
+        // If validation is requested, run full chain/traits validation for schemas
+        // and instance validation for instances.
+        if validate && entity.is_schema {
+            if let Err(e) = self.store.validate_schema_chain(&entity_id) {
+                return GtsAddEntityResult {
+                    ok: false,
+                    id: String::new(),
+                    schema_id: None,
+                    is_schema: true,
+                    error: format!(
+                        "Schema chain validation failed: {e}\n{}",
+                        self.get_details(&entity)
+                    ),
+                };
+            }
+            if let Err(e) = self.store.validate_schema_traits(&entity_id) {
+                return GtsAddEntityResult {
+                    ok: false,
+                    id: String::new(),
+                    schema_id: None,
+                    is_schema: true,
+                    error: format!(
+                        "Schema traits validation failed: {e}\n{}",
+                        self.get_details(&entity)
+                    ),
+                };
+            }
+        }
+
+        if validate && !entity.is_schema {
+            if let Err(e) = crate::schema_modifiers::validate_instance_modifiers(&entity.content) {
+                return GtsAddEntityResult {
+                    ok: false,
+                    id: String::new(),
+                    schema_id: None,
+                    is_schema: false,
+                    error: format!(
+                        "Instance validation failed: {e}\n{}",
+                        self.get_details(&entity)
+                    ),
+                };
+            }
+            if let Err(e) = self.store.validate_instance(&entity_id) {
+                return GtsAddEntityResult {
+                    ok: false,
+                    id: String::new(),
+                    schema_id: None,
+                    is_schema: false,
+                    error: format!(
+                        "Instance validation failed: {e}\n{}",
+                        self.get_details(&entity)
+                    ),
+                };
+            }
         }
 
         // println!("submitted: {}", self.get_content_pretty(&entity));
@@ -619,6 +672,19 @@ impl GtsOps {
 
     pub fn validate_entity(&mut self, gts_id: &str) -> GtsEntityValidationResult {
         if gts_id.ends_with('~') {
+            // Validate schema modifiers (x-gts-final, x-gts-abstract): types,
+            // mutual exclusion, and top-level placement.
+            if let Some(entity) = self.store.get(gts_id)
+                && let Err(e) = crate::schema_modifiers::validate_schema_modifiers(&entity.content)
+            {
+                return GtsEntityValidationResult {
+                    id: gts_id.to_owned(),
+                    ok: false,
+                    entity_type: "schema".to_owned(),
+                    error: e,
+                };
+            }
+
             let result = self.validate_schema(gts_id);
             if !result.ok {
                 return GtsEntityValidationResult {
@@ -649,6 +715,19 @@ impl GtsOps {
                 error: String::new(),
             }
         } else {
+            // Check that schema-only keywords do not appear in instance content.
+            if let Some(entity) = self.store.get(gts_id)
+                && let Err(e) =
+                    crate::schema_modifiers::validate_instance_modifiers(&entity.content)
+            {
+                return GtsEntityValidationResult {
+                    id: gts_id.to_owned(),
+                    ok: false,
+                    entity_type: "instance".to_owned(),
+                    error: e,
+                };
+            }
+
             let result = self.validate_instance(gts_id);
             GtsEntityValidationResult {
                 id: result.id,
@@ -3262,6 +3341,38 @@ mod tests {
         assert!(
             result.error.contains("Instance validation failed"),
             "Error should mention instance validation failure, got: {}",
+            result.error
+        );
+    }
+
+    #[test]
+    fn test_add_entity_validate_rejects_instance_with_schema_only_keyword() {
+        // Registration with validate=true MUST reject an instance whose body
+        // contains schema-only keywords (x-gts-final / x-gts-abstract).
+        let mut ops = GtsOps::new(None, None, 0);
+
+        let schema = json!({
+            "$id": "gts://gts.x.testkw.host.thing.v1~",
+            "$schema": "http://json-schema.org/draft-07/schema#",
+            "type": "object",
+            "properties": {"name": {"type": "string"}},
+            "required": ["name"],
+        });
+        assert!(ops.add_entity(&schema, false).ok);
+
+        let bad_instance = json!({
+            "id": "gts.x.testkw.host.thing.v1~x.testkw._.item.v1",
+            "name": "leak",
+            "x-gts-final": true,
+        });
+        let result = ops.add_entity(&bad_instance, true);
+        assert!(
+            !result.ok,
+            "instance with schema-only keyword must be rejected"
+        );
+        assert!(
+            result.error.contains("x-gts-final"),
+            "error should name the offending keyword, got: {}",
             result.error
         );
     }

--- a/gts/src/schema_modifiers.rs
+++ b/gts/src/schema_modifiers.rs
@@ -1,0 +1,801 @@
+use serde_json::Value;
+
+pub const X_GTS_FINAL: &str = "x-gts-final";
+pub const X_GTS_ABSTRACT: &str = "x-gts-abstract";
+
+fn contains_key_recursive(value: &Value, key: &str) -> bool {
+    match value {
+        Value::Object(map) => {
+            if map.contains_key(key) {
+                return true;
+            }
+            map.values().any(|v| contains_key_recursive(v, key))
+        }
+        Value::Array(arr) => arr.iter().any(|v| contains_key_recursive(v, key)),
+        _ => false,
+    }
+}
+
+/// Validate `x-gts-final` and `x-gts-abstract` on a schema:
+/// - both must be booleans,
+/// - they are mutually exclusive when both true,
+/// - they must appear only at the schema top level — anywhere nested
+///   (inside `allOf`, `properties`, `$defs`, `items`, combinators, etc.) is rejected.
+///
+/// # Errors
+/// Returns an error describing the first failed check.
+pub fn validate_schema_modifiers(content: &Value) -> Result<(), String> {
+    let is_final = match content.get(X_GTS_FINAL) {
+        Some(Value::Bool(b)) => *b,
+        Some(other) => return Err(format!("{X_GTS_FINAL} must be a boolean, got {other}")),
+        None => false,
+    };
+
+    let is_abstract = match content.get(X_GTS_ABSTRACT) {
+        Some(Value::Bool(b)) => *b,
+        Some(other) => return Err(format!("{X_GTS_ABSTRACT} must be a boolean, got {other}")),
+        None => false,
+    };
+
+    if is_final && is_abstract {
+        return Err(format!(
+            "schema cannot declare both {X_GTS_FINAL} and {X_GTS_ABSTRACT} as true"
+        ));
+    }
+
+    if let Value::Object(map) = content {
+        for (k, v) in map {
+            if k == X_GTS_FINAL || k == X_GTS_ABSTRACT {
+                continue;
+            }
+            if contains_key_recursive(v, X_GTS_FINAL) {
+                return Err(format!("{X_GTS_FINAL} must be at the schema top level"));
+            }
+            if contains_key_recursive(v, X_GTS_ABSTRACT) {
+                return Err(format!("{X_GTS_ABSTRACT} must be at the schema top level"));
+            }
+        }
+    }
+
+    Ok(())
+}
+
+/// Check that schema-only keywords (`x-gts-final`, `x-gts-abstract`) do not appear anywhere
+/// in instance content.
+///
+/// # Errors
+/// Returns error if any schema-only keyword is found in the content (top-level or nested).
+pub fn validate_instance_modifiers(content: &Value) -> Result<(), String> {
+    if contains_key_recursive(content, X_GTS_FINAL) {
+        return Err(format!(
+            "{X_GTS_FINAL} is a schema-only keyword and must not appear in instances"
+        ));
+    }
+    if contains_key_recursive(content, X_GTS_ABSTRACT) {
+        return Err(format!(
+            "{X_GTS_ABSTRACT} is a schema-only keyword and must not appear in instances"
+        ));
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+#[allow(clippy::unwrap_used, clippy::expect_used)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    // =========================================================================
+    // validate_schema_modifiers unit tests
+    // =========================================================================
+
+    #[test]
+    fn test_default() {
+        assert!(validate_schema_modifiers(&json!({"type": "object"})).is_ok());
+    }
+
+    #[test]
+    fn test_final_true() {
+        assert!(validate_schema_modifiers(&json!({"x-gts-final": true})).is_ok());
+    }
+
+    #[test]
+    fn test_abstract_true() {
+        assert!(validate_schema_modifiers(&json!({"x-gts-abstract": true})).is_ok());
+    }
+
+    #[test]
+    fn test_both_true_error() {
+        let result = validate_schema_modifiers(&json!({
+            "x-gts-final": true,
+            "x-gts-abstract": true,
+        }));
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_non_boolean_final() {
+        let result = validate_schema_modifiers(&json!({"x-gts-final": "yes"}));
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_non_boolean_abstract() {
+        let result = validate_schema_modifiers(&json!({"x-gts-abstract": 1}));
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_false_is_noop() {
+        assert!(
+            validate_schema_modifiers(&json!({
+                "x-gts-final": false,
+                "x-gts-abstract": false,
+            }))
+            .is_ok()
+        );
+    }
+
+    #[test]
+    fn test_final_inside_allof_rejected() {
+        let result = validate_schema_modifiers(&json!({
+            "type": "object",
+            "allOf": [
+                {"$ref": "gts.x.foo.base.v1~"},
+                {"x-gts-final": true},
+            ],
+        }));
+        assert!(result.is_err());
+        assert!(result.unwrap_err().contains("x-gts-final"));
+    }
+
+    #[test]
+    fn test_abstract_inside_allof_rejected() {
+        let result = validate_schema_modifiers(&json!({
+            "type": "object",
+            "allOf": [
+                {"$ref": "gts.x.foo.base.v1~"},
+                {"x-gts-abstract": true},
+            ],
+        }));
+        assert!(result.is_err());
+        assert!(result.unwrap_err().contains("x-gts-abstract"));
+    }
+
+    #[test]
+    fn test_top_level_with_allof_ok() {
+        assert!(
+            validate_schema_modifiers(&json!({
+                "type": "object",
+                "x-gts-final": true,
+                "allOf": [
+                    {"$ref": "gts.x.foo.base.v1~"},
+                    {"type": "object"},
+                ],
+            }))
+            .is_ok()
+        );
+    }
+
+    #[test]
+    fn test_final_inside_properties_rejected() {
+        let result = validate_schema_modifiers(&json!({
+            "type": "object",
+            "properties": {
+                "foo": {"type": "string", "x-gts-final": true},
+            },
+        }));
+        assert!(result.is_err());
+        assert!(result.unwrap_err().contains("x-gts-final"));
+    }
+
+    #[test]
+    fn test_abstract_inside_defs_rejected() {
+        let result = validate_schema_modifiers(&json!({
+            "type": "object",
+            "$defs": {
+                "Inner": {"type": "object", "x-gts-abstract": true},
+            },
+        }));
+        assert!(result.is_err());
+        assert!(result.unwrap_err().contains("x-gts-abstract"));
+    }
+
+    #[test]
+    fn test_final_inside_oneof_rejected() {
+        let result = validate_schema_modifiers(&json!({
+            "type": "object",
+            "oneOf": [
+                {"type": "object"},
+                {"type": "object", "x-gts-final": true},
+            ],
+        }));
+        assert!(result.is_err());
+        assert!(result.unwrap_err().contains("x-gts-final"));
+    }
+
+    #[test]
+    fn test_abstract_inside_items_rejected() {
+        let result = validate_schema_modifiers(&json!({
+            "type": "array",
+            "items": {"type": "object", "x-gts-abstract": true},
+        }));
+        assert!(result.is_err());
+        assert!(result.unwrap_err().contains("x-gts-abstract"));
+    }
+
+    // =========================================================================
+    // validate_instance_modifiers unit tests
+    // =========================================================================
+
+    #[test]
+    fn test_instance_clean() {
+        assert!(validate_instance_modifiers(&json!({"id": "test", "name": "foo"})).is_ok());
+    }
+
+    #[test]
+    fn test_instance_has_final() {
+        let result = validate_instance_modifiers(&json!({"id": "test", "x-gts-final": true}));
+        assert!(result.is_err());
+        assert!(result.unwrap_err().contains("x-gts-final"));
+    }
+
+    #[test]
+    fn test_instance_has_abstract() {
+        let result = validate_instance_modifiers(&json!({"id": "test", "x-gts-abstract": true}));
+        assert!(result.is_err());
+        assert!(result.unwrap_err().contains("x-gts-abstract"));
+    }
+
+    #[test]
+    fn test_instance_nested_final_rejected() {
+        let result = validate_instance_modifiers(&json!({
+            "id": "test",
+            "metadata": {"flags": {"x-gts-final": true}},
+        }));
+        assert!(result.is_err());
+        assert!(result.unwrap_err().contains("x-gts-final"));
+    }
+
+    #[test]
+    fn test_instance_nested_abstract_in_array_rejected() {
+        let result = validate_instance_modifiers(&json!({
+            "id": "test",
+            "items": [
+                {"name": "ok"},
+                {"name": "bad", "x-gts-abstract": true},
+            ],
+        }));
+        assert!(result.is_err());
+        assert!(result.unwrap_err().contains("x-gts-abstract"));
+    }
+
+    // =========================================================================
+    // Integration tests via store
+    // =========================================================================
+
+    use crate::entities::{GtsConfig, GtsEntity};
+    use crate::store::GtsStore;
+
+    fn default_config() -> GtsConfig {
+        GtsConfig::default()
+    }
+
+    fn reg_schema(store: &mut GtsStore, content: Value) {
+        // Ensure $id has gts:// prefix for entity detection
+        let content = if let Some(id) = content.get("$id").and_then(|v| v.as_str()) {
+            if id.starts_with("gts://") {
+                content
+            } else {
+                let mut c = content.as_object().unwrap().clone();
+                c.insert("$id".to_owned(), json!(format!("gts://{id}")));
+                Value::Object(c)
+            }
+        } else {
+            content
+        };
+        let cfg = default_config();
+        let entity = GtsEntity::new(
+            None,
+            None,
+            &content,
+            Some(&cfg),
+            None,
+            false,
+            String::new(),
+            None,
+            None,
+        );
+        store.register(entity).expect("register failed");
+    }
+
+    fn reg_instance(store: &mut GtsStore, content: &Value) {
+        let cfg = default_config();
+        let entity = GtsEntity::new(
+            None,
+            None,
+            content,
+            Some(&cfg),
+            None,
+            false,
+            String::new(),
+            None,
+            None,
+        );
+        store.register(entity).expect("register instance failed");
+    }
+
+    // -- x-gts-final tests --
+
+    #[test]
+    fn test_final_reject_derived_schema() {
+        let mut store = GtsStore::new(None);
+        reg_schema(
+            &mut store,
+            json!({
+                "$id": "gts.x.testmod.final.base.v1~",
+                "$schema": "http://json-schema.org/draft-07/schema#",
+                "type": "object",
+                "x-gts-final": true,
+                "properties": {"name": {"type": "string"}},
+            }),
+        );
+        reg_schema(
+            &mut store,
+            json!({
+                "$id": "gts.x.testmod.final.base.v1~x.testmod._.derived.v1~",
+                "$schema": "http://json-schema.org/draft-07/schema#",
+                "type": "object",
+                "allOf": [
+                    {"$ref": "gts.x.testmod.final.base.v1~"},
+                    {"type": "object", "properties": {"extra": {"type": "string"}}},
+                ],
+            }),
+        );
+        let result =
+            store.validate_schema_chain("gts.x.testmod.final.base.v1~x.testmod._.derived.v1~");
+        assert!(result.is_err());
+        assert!(result.unwrap_err().to_string().contains("final"));
+    }
+
+    #[test]
+    fn test_final_allow_well_known_instance() {
+        let mut store = GtsStore::new(None);
+        reg_schema(
+            &mut store,
+            json!({
+                "$id": "gts.x.testmod.final.inst.v1~",
+                "$schema": "http://json-schema.org/draft-07/schema#",
+                "type": "object",
+                "x-gts-final": true,
+                "required": ["id", "description"],
+                "properties": {
+                    "id": {"type": "string"},
+                    "description": {"type": "string"},
+                },
+            }),
+        );
+        reg_instance(
+            &mut store,
+            &json!({
+                "id": "gts.x.testmod.final.inst.v1~x.testmod._.running.v1",
+                "description": "Running state",
+            }),
+        );
+        let result = store.validate_instance("gts.x.testmod.final.inst.v1~x.testmod._.running.v1");
+        assert!(
+            result.is_ok(),
+            "expected instance of final type to pass: {result:?}"
+        );
+    }
+
+    #[test]
+    fn test_final_mid_chain() {
+        let mut store = GtsStore::new(None);
+        reg_schema(
+            &mut store,
+            json!({
+                "$id": "gts.x.testmod.finalmid.base.v1~",
+                "$schema": "http://json-schema.org/draft-07/schema#",
+                "type": "object",
+                "properties": {"name": {"type": "string"}},
+            }),
+        );
+        reg_schema(
+            &mut store,
+            json!({
+                "$id": "gts.x.testmod.finalmid.base.v1~x.testmod._.mid.v1~",
+                "$schema": "http://json-schema.org/draft-07/schema#",
+                "type": "object",
+                "x-gts-final": true,
+                "allOf": [
+                    {"$ref": "gts.x.testmod.finalmid.base.v1~"},
+                    {"type": "object"},
+                ],
+            }),
+        );
+        reg_schema(
+            &mut store,
+            json!({
+                "$id": "gts.x.testmod.finalmid.base.v1~x.testmod._.mid.v1~x.testmod._.leaf.v1~",
+                "$schema": "http://json-schema.org/draft-07/schema#",
+                "type": "object",
+                "allOf": [
+                    {"$ref": "gts.x.testmod.finalmid.base.v1~x.testmod._.mid.v1~"},
+                    {"type": "object"},
+                ],
+            }),
+        );
+        let result = store.validate_schema_chain(
+            "gts.x.testmod.finalmid.base.v1~x.testmod._.mid.v1~x.testmod._.leaf.v1~",
+        );
+        assert!(
+            result.is_err(),
+            "expected mid-chain final to block derivation"
+        );
+    }
+
+    #[test]
+    fn test_final_sibling_unaffected() {
+        let mut store = GtsStore::new(None);
+        reg_schema(
+            &mut store,
+            json!({
+                "$id": "gts.x.testmod.finalsib.base.v1~",
+                "$schema": "http://json-schema.org/draft-07/schema#",
+                "type": "object",
+                "properties": {"name": {"type": "string"}},
+            }),
+        );
+        reg_schema(
+            &mut store,
+            json!({
+                "$id": "gts.x.testmod.finalsib.base.v1~x.testmod._.final_b.v1~",
+                "$schema": "http://json-schema.org/draft-07/schema#",
+                "type": "object",
+                "x-gts-final": true,
+                "allOf": [
+                    {"$ref": "gts.x.testmod.finalsib.base.v1~"},
+                    {"type": "object"},
+                ],
+            }),
+        );
+        reg_schema(
+            &mut store,
+            json!({
+                "$id": "gts.x.testmod.finalsib.base.v1~x.testmod._.sibling_c.v1~",
+                "$schema": "http://json-schema.org/draft-07/schema#",
+                "type": "object",
+                "allOf": [
+                    {"$ref": "gts.x.testmod.finalsib.base.v1~"},
+                    {"type": "object", "properties": {"extra": {"type": "string"}}},
+                ],
+            }),
+        );
+        let result =
+            store.validate_schema_chain("gts.x.testmod.finalsib.base.v1~x.testmod._.sibling_c.v1~");
+        assert!(result.is_ok(), "sibling should pass: {result:?}");
+    }
+
+    #[test]
+    fn test_final_false_is_noop() {
+        let mut store = GtsStore::new(None);
+        reg_schema(
+            &mut store,
+            json!({
+                "$id": "gts.x.testmod.finalfalse.base.v1~",
+                "$schema": "http://json-schema.org/draft-07/schema#",
+                "type": "object",
+                "x-gts-final": false,
+                "properties": {"name": {"type": "string"}},
+            }),
+        );
+        reg_schema(
+            &mut store,
+            json!({
+                "$id": "gts.x.testmod.finalfalse.base.v1~x.testmod._.derived.v1~",
+                "$schema": "http://json-schema.org/draft-07/schema#",
+                "type": "object",
+                "allOf": [
+                    {"$ref": "gts.x.testmod.finalfalse.base.v1~"},
+                    {"type": "object"},
+                ],
+            }),
+        );
+        let result =
+            store.validate_schema_chain("gts.x.testmod.finalfalse.base.v1~x.testmod._.derived.v1~");
+        assert!(
+            result.is_ok(),
+            "final=false should allow derivation: {result:?}"
+        );
+    }
+
+    // -- x-gts-abstract tests --
+
+    #[test]
+    fn test_abstract_reject_direct_instance() {
+        let mut store = GtsStore::new(None);
+        reg_schema(
+            &mut store,
+            json!({
+                "$id": "gts.x.testmod.abs.reject.v1~",
+                "$schema": "http://json-schema.org/draft-07/schema#",
+                "type": "object",
+                "x-gts-abstract": true,
+                "required": ["id", "name"],
+                "properties": {
+                    "id": {"type": "string"},
+                    "name": {"type": "string"},
+                },
+            }),
+        );
+        reg_instance(
+            &mut store,
+            &json!({
+                "id": "gts.x.testmod.abs.reject.v1~x.testmod._.item.v1",
+                "name": "Direct item",
+            }),
+        );
+        let result = store.validate_instance("gts.x.testmod.abs.reject.v1~x.testmod._.item.v1");
+        assert!(result.is_err());
+        assert!(result.unwrap_err().to_string().contains("abstract"));
+    }
+
+    #[test]
+    fn test_abstract_allow_derived_schema() {
+        let mut store = GtsStore::new(None);
+        reg_schema(
+            &mut store,
+            json!({
+                "$id": "gts.x.testmod.abs.derive.v1~",
+                "$schema": "http://json-schema.org/draft-07/schema#",
+                "type": "object",
+                "x-gts-abstract": true,
+                "properties": {"name": {"type": "string"}},
+            }),
+        );
+        reg_schema(
+            &mut store,
+            json!({
+                "$id": "gts.x.testmod.abs.derive.v1~x.testmod._.concrete.v1~",
+                "$schema": "http://json-schema.org/draft-07/schema#",
+                "type": "object",
+                "allOf": [
+                    {"$ref": "gts.x.testmod.abs.derive.v1~"},
+                    {"type": "object", "properties": {"extra": {"type": "string"}}},
+                ],
+            }),
+        );
+        let result =
+            store.validate_schema_chain("gts.x.testmod.abs.derive.v1~x.testmod._.concrete.v1~");
+        assert!(
+            result.is_ok(),
+            "derived from abstract should pass: {result:?}"
+        );
+    }
+
+    #[test]
+    fn test_abstract_allow_instance_of_concrete_derived() {
+        let mut store = GtsStore::new(None);
+        reg_schema(
+            &mut store,
+            json!({
+                "$id": "gts.x.testmod.abs.concinst.v1~",
+                "$schema": "http://json-schema.org/draft-07/schema#",
+                "type": "object",
+                "x-gts-abstract": true,
+                "required": ["id", "name"],
+                "properties": {
+                    "id": {"type": "string"},
+                    "name": {"type": "string"},
+                },
+            }),
+        );
+        reg_schema(
+            &mut store,
+            json!({
+                "$id": "gts.x.testmod.abs.concinst.v1~x.testmod._.concrete.v1~",
+                "$schema": "http://json-schema.org/draft-07/schema#",
+                "type": "object",
+                "allOf": [
+                    {"$ref": "gts.x.testmod.abs.concinst.v1~"},
+                    {"type": "object"},
+                ],
+            }),
+        );
+        reg_instance(
+            &mut store,
+            &json!({
+                "id": "gts.x.testmod.abs.concinst.v1~x.testmod._.concrete.v1~x.testmod._.item.v1",
+                "name": "My Item",
+            }),
+        );
+        let result = store.validate_instance(
+            "gts.x.testmod.abs.concinst.v1~x.testmod._.concrete.v1~x.testmod._.item.v1",
+        );
+        assert!(
+            result.is_ok(),
+            "instance of concrete derived should pass: {result:?}"
+        );
+    }
+
+    #[test]
+    fn test_abstract_chain_of_abstracts() {
+        let mut store = GtsStore::new(None);
+        reg_schema(
+            &mut store,
+            json!({
+                "$id": "gts.x.testmod.abs.chain.v1~",
+                "$schema": "http://json-schema.org/draft-07/schema#",
+                "type": "object",
+                "x-gts-abstract": true,
+                "required": ["id"],
+                "properties": {"id": {"type": "string"}},
+            }),
+        );
+        reg_schema(
+            &mut store,
+            json!({
+                "$id": "gts.x.testmod.abs.chain.v1~x.testmod._.mid.v1~",
+                "$schema": "http://json-schema.org/draft-07/schema#",
+                "type": "object",
+                "x-gts-abstract": true,
+                "allOf": [
+                    {"$ref": "gts.x.testmod.abs.chain.v1~"},
+                    {"type": "object"},
+                ],
+            }),
+        );
+        reg_schema(
+            &mut store,
+            json!({
+                "$id": "gts.x.testmod.abs.chain.v1~x.testmod._.mid.v1~x.testmod._.leaf.v1~",
+                "$schema": "http://json-schema.org/draft-07/schema#",
+                "type": "object",
+                "allOf": [
+                    {"$ref": "gts.x.testmod.abs.chain.v1~x.testmod._.mid.v1~"},
+                    {"type": "object"},
+                ],
+            }),
+        );
+        // Instance of concrete leaf — pass
+        reg_instance(
+            &mut store,
+            &json!({
+                "id": "gts.x.testmod.abs.chain.v1~x.testmod._.mid.v1~x.testmod._.leaf.v1~x.testmod._.item.v1",
+            }),
+        );
+        assert!(store.validate_instance(
+            "gts.x.testmod.abs.chain.v1~x.testmod._.mid.v1~x.testmod._.leaf.v1~x.testmod._.item.v1"
+        ).is_ok());
+        // Instance of abstract mid — fail
+        reg_instance(
+            &mut store,
+            &json!({
+                "id": "gts.x.testmod.abs.chain.v1~x.testmod._.mid.v1~x.testmod._.direct.v1",
+            }),
+        );
+        assert!(
+            store
+                .validate_instance(
+                    "gts.x.testmod.abs.chain.v1~x.testmod._.mid.v1~x.testmod._.direct.v1"
+                )
+                .is_err()
+        );
+    }
+
+    #[test]
+    fn test_abstract_false_is_noop() {
+        let mut store = GtsStore::new(None);
+        reg_schema(
+            &mut store,
+            json!({
+                "$id": "gts.x.testmod.absfalse.base.v1~",
+                "$schema": "http://json-schema.org/draft-07/schema#",
+                "type": "object",
+                "x-gts-abstract": false,
+                "required": ["id"],
+                "properties": {"id": {"type": "string"}},
+            }),
+        );
+        reg_instance(
+            &mut store,
+            &json!({
+                "id": "gts.x.testmod.absfalse.base.v1~x.testmod._.item.v1",
+            }),
+        );
+        assert!(
+            store
+                .validate_instance("gts.x.testmod.absfalse.base.v1~x.testmod._.item.v1")
+                .is_ok()
+        );
+    }
+
+    // -- Interaction tests --
+
+    #[test]
+    fn test_abstract_base_final_derived() {
+        let mut store = GtsStore::new(None);
+        reg_schema(
+            &mut store,
+            json!({
+                "$id": "gts.x.testmod.absfinal.base.v1~",
+                "$schema": "http://json-schema.org/draft-07/schema#",
+                "type": "object",
+                "x-gts-abstract": true,
+                "required": ["id", "name"],
+                "properties": {
+                    "id": {"type": "string"},
+                    "name": {"type": "string"},
+                },
+            }),
+        );
+        reg_schema(
+            &mut store,
+            json!({
+                "$id": "gts.x.testmod.absfinal.base.v1~x.testmod._.concrete.v1~",
+                "$schema": "http://json-schema.org/draft-07/schema#",
+                "type": "object",
+                "x-gts-final": true,
+                "allOf": [
+                    {"$ref": "gts.x.testmod.absfinal.base.v1~"},
+                    {"type": "object", "properties": {"extra": {"type": "string"}}},
+                ],
+            }),
+        );
+        // B chain valid
+        assert!(
+            store
+                .validate_schema_chain("gts.x.testmod.absfinal.base.v1~x.testmod._.concrete.v1~")
+                .is_ok()
+        );
+        // Instance of B — pass
+        reg_instance(
+            &mut store,
+            &json!({
+                "id": "gts.x.testmod.absfinal.base.v1~x.testmod._.concrete.v1~x.testmod._.item.v1",
+                "name": "My Item", "extra": "value",
+            }),
+        );
+        assert!(
+            store
+                .validate_instance(
+                    "gts.x.testmod.absfinal.base.v1~x.testmod._.concrete.v1~x.testmod._.item.v1"
+                )
+                .is_ok()
+        );
+        // Derived from B — fail (B is final)
+        reg_schema(
+            &mut store,
+            json!({
+                "$id": "gts.x.testmod.absfinal.base.v1~x.testmod._.concrete.v1~x.testmod._.sub.v1~",
+                "$schema": "http://json-schema.org/draft-07/schema#",
+                "type": "object",
+                "allOf": [
+                    {"$ref": "gts.x.testmod.absfinal.base.v1~x.testmod._.concrete.v1~"},
+                    {"type": "object"},
+                ],
+            }),
+        );
+        assert!(
+            store
+                .validate_schema_chain(
+                    "gts.x.testmod.absfinal.base.v1~x.testmod._.concrete.v1~x.testmod._.sub.v1~"
+                )
+                .is_err()
+        );
+        // Direct instance of A — fail (A is abstract)
+        reg_instance(
+            &mut store,
+            &json!({
+                "id": "gts.x.testmod.absfinal.base.v1~x.testmod._.direct.v1",
+                "name": "Direct from abstract",
+            }),
+        );
+        assert!(
+            store
+                .validate_instance("gts.x.testmod.absfinal.base.v1~x.testmod._.direct.v1")
+                .is_err()
+        );
+    }
+}

--- a/gts/src/store.rs
+++ b/gts/src/store.rs
@@ -756,6 +756,18 @@ impl GtsStore {
                     .join("")
             );
 
+            // Check x-gts-final: if the base type is final, derivation is not allowed.
+            if let Some(base_entity) = self.get(&base_id)
+                && base_entity
+                    .content
+                    .get(crate::schema_modifiers::X_GTS_FINAL)
+                    == Some(&Value::Bool(true))
+            {
+                return Err(StoreError::ValidationError(format!(
+                    "base type '{base_id}' is final and cannot be extended"
+                )));
+            }
+
             tracing::info!(
                 "OP#12: Validating schema chain pair: base={} derived={}",
                 base_id,
@@ -927,6 +939,17 @@ impl GtsStore {
             resolved_trait_schemas.push(resolved);
         }
 
+        // Check if the leaf schema is abstract — skip trait validation entirely.
+        // Abstract schemas are not leaf schemas, so trait resolution completeness is not enforced.
+        if let Some(leaf_entity) = self.get(gts_id)
+            && leaf_entity
+                .content
+                .get(crate::schema_modifiers::X_GTS_ABSTRACT)
+                == Some(&Value::Bool(true))
+        {
+            return Ok(());
+        }
+
         // Delegate to the schema_traits module
         let merged = serde_json::Value::Object(merged_traits);
         crate::schema_traits::validate_effective_traits(&resolved_trait_schemas, &merged, true)
@@ -1037,6 +1060,13 @@ impl GtsStore {
             .clone();
 
         let schema = self.get_schema_content(&schema_id)?;
+
+        // Check x-gts-abstract: abstract types cannot have direct instances.
+        if schema.get(crate::schema_modifiers::X_GTS_ABSTRACT) == Some(&Value::Bool(true)) {
+            return Err(StoreError::ValidationError(format!(
+                "type '{schema_id}' is abstract and cannot have direct instances"
+            )));
+        }
 
         tracing::info!(
             "Validating instance {} against schema {}",


### PR DESCRIPTION
- Validate that x-gts-final and x-gts-abstract are booleans, mutually exclusive, and only at schema top level (not inside allOf)
- Reject derivation from a base type marked x-gts-final
- Reject direct instances of types marked x-gts-abstract
- Skip trait completeness checks for abstract leaf schemas
- Block schema-only keywords from appearing in instance content
- Bump .gts-spec submodule to pick up 0.9 conformance tests
- Rework make e2e: bootstrap a dedicated venv (.gts-spec/.venv), make PORT/PYTHON overridable, and ensure the server is always cleaned up on exit

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added schema-level "final" and "abstract" modifiers with validation that affect schema inheritance and instance acceptance.

* **Documentation**
  * Added detailed instructions for running the end-to-end conformance suite and macOS troubleshooting.

* **Chores**
  * e2e test flow: venv bootstrapping, configurable port, improved startup/cleanup.
  * Updated submodule pointer and ignored end-to-end log file.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->