### PR TITLE
feat: add gts_instance! and gts_instance_raw! construction macros

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,29 +27,9 @@ env:
   CARGO_INCREMENTAL: "0"
 
 jobs:
-  read-rust-version:
-    name: Read Rust version
-    runs-on: ubuntu-latest
-    outputs:
-      rust-version: ${{ steps.read-version.outputs.version }}
-    steps:
-      - name: Checkout
-        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
-
-      - name: Read Rust version from Cargo.toml
-        id: read-version
-        shell: bash
-        run: |
-          version=$(awk -F'"' '/^[[:space:]]*rust-version[[:space:]]*=/{print $2; exit}' Cargo.toml)
-          if [ -z "$version" ]; then
-            echo "Failed to read rust-version from Cargo.toml" >&2
-            exit 1
-          fi
-          echo "version=$version" >> $GITHUB_OUTPUT
   test:
-    name: Test Suite (${{ matrix.os }}, rust=${{ needs.read-rust-version.outputs.rust-version }})
+    name: Test Suite (${{ matrix.os }})
     runs-on: ${{ matrix.os }}
-    needs: read-rust-version
     strategy:
       fail-fast: false
       matrix:
@@ -69,11 +49,10 @@ jobs:
           clean: 'true'
           submodules: recursive
 
-      - name: Install Rust toolchain
-        uses: dtolnay/rust-toolchain@9bc92bc5598b4f3bec5d910d352094982cb0c3b9 # stable
-        with:
-          toolchain: "${{ needs.read-rust-version.outputs.rust-version }}"
-          components: rustfmt, clippy
+      - name: Install Rust toolchain from rust-toolchain.toml
+        run: |
+          rustup show active-toolchain || rustup toolchain install
+          rustup show
 
       # Cache Cargo registry/git + target/ across platforms.
       - name: Cache Cargo/target
@@ -143,17 +122,16 @@ jobs:
   security:
     name: Security (cargo-deny on Ubuntu)
     runs-on: ubuntu-latest
-    needs: read-rust-version
     steps:
       - name: Checkout
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           submodules: recursive
 
-      - name: Install Rust toolchain
-        uses: dtolnay/rust-toolchain@9bc92bc5598b4f3bec5d910d352094982cb0c3b9 # stable
-        with:
-          toolchain: "${{ needs.read-rust-version.outputs.rust-version }}"
+      - name: Install Rust toolchain from rust-toolchain.toml
+        run: |
+          rustup show active-toolchain || rustup toolchain install
+          rustup show
 
       - name: Cache Cargo/target
         uses: Swatinem/rust-cache@9d47c6ad4b02e050fd481d890b2ea34778fd09d6 # v2.7.8
@@ -172,18 +150,17 @@ jobs:
   coverage:
     name: Code Coverage (cargo-llvm-cov)
     runs-on: ubuntu-latest
-    needs: read-rust-version
     steps:
       - name: Checkout
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           submodules: recursive
 
-      - name: Install Rust toolchain (with llvm-tools)
-        uses: dtolnay/rust-toolchain@9bc92bc5598b4f3bec5d910d352094982cb0c3b9 # stable
-        with:
-          toolchain: "${{ needs.read-rust-version.outputs.rust-version }}"
-          components: llvm-tools-preview
+      - name: Install Rust toolchain from rust-toolchain.toml (with llvm-tools)
+        run: |
+          rustup show active-toolchain || rustup toolchain install
+          rustup component add llvm-tools-preview
+          rustup show
 
       - name: Cache Cargo/target
         uses: Swatinem/rust-cache@9d47c6ad4b02e050fd481d890b2ea34778fd09d6 # v2.7.8
@@ -243,7 +220,6 @@ jobs:
   e2e:
     name: E2E Tests (gts-spec)
     runs-on: ubuntu-latest
-    needs: read-rust-version
     env:
       PYTHONDONTWRITEBYTECODE: 1
     steps:
@@ -252,10 +228,10 @@ jobs:
         with:
           submodules: recursive
 
-      - name: Install Rust toolchain
-        uses: dtolnay/rust-toolchain@9bc92bc5598b4f3bec5d910d352094982cb0c3b9 # stable
-        with:
-          toolchain: "${{ needs.read-rust-version.outputs.rust-version }}"
+      - name: Install Rust toolchain from rust-toolchain.toml
+        run: |
+          rustup show active-toolchain || rustup toolchain install
+          rustup show
 
       - name: Cache Cargo/target
         uses: Swatinem/rust-cache@9d47c6ad4b02e050fd481d890b2ea34778fd09d6 # v2.7.8

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -25,7 +25,6 @@ jobs:
     timeout-minutes: 30
     outputs:
       version: ${{ steps.check.outputs.version }}
-      rust-version: ${{ steps.check.outputs.rust-version }}
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
@@ -114,13 +113,7 @@ jobs:
           done
           [ $FAIL -eq 0 ] || exit 1
 
-          RUST_VER=$(awk -F'"' '/^[[:space:]]*rust-version[[:space:]]*=/{print $2; exit}' Cargo.toml)
-          if [ -z "${RUST_VER}" ]; then
-            echo "WARNING: rust-version not found in Cargo.toml, defaulting to 'stable'"
-            RUST_VER="stable"
-          fi
           echo "version=${EXPECTED}" >> "$GITHUB_OUTPUT"
-          echo "rust-version=${RUST_VER}" >> "$GITHUB_OUTPUT"
 
       - name: Install cargo-deny
         uses: taiki-e/install-action@385db9cc6bf65d19775b02084a4b698eaca9a4f2 # v2
@@ -185,10 +178,11 @@ jobs:
             exit 1
           fi
 
-      - uses: dtolnay/rust-toolchain@9bc92bc5598b4f3bec5d910d352094982cb0c3b9 # stable
-        with:
-          toolchain: ${{ needs.validate.outputs.rust-version }}
-          targets: ${{ matrix.target }}
+      - name: Install Rust toolchain from rust-toolchain.toml
+        run: |
+          rustup show active-toolchain || rustup toolchain install
+          rustup target add ${{ matrix.target }}
+          rustup show
 
       - uses: Swatinem/rust-cache@9d47c6ad4b02e050fd481d890b2ea34778fd09d6 # v2.7.8
         with:
@@ -436,9 +430,10 @@ jobs:
         with:
           persist-credentials: false
 
-      - uses: dtolnay/rust-toolchain@9bc92bc5598b4f3bec5d910d352094982cb0c3b9 # stable
-        with:
-          toolchain: ${{ needs.validate.outputs.rust-version }}
+      - name: Install Rust toolchain from rust-toolchain.toml
+        run: |
+          rustup show active-toolchain || rustup toolchain install
+          rustup show
 
       - uses: Swatinem/rust-cache@9d47c6ad4b02e050fd481d890b2ea34778fd09d6 # v2.7.8
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ license = "Apache-2.0"
 authors = ["GTS Community"]
 repository = "https://github.com/GlobalTypeSystem/gts-rust"
 description = "Global Type System implementation in rust"
-rust-version = "1.92.0"
+rust-version = "1.95.0"
 categories = ["development-tools::build-utils"]
 readme = "README.md"
 

--- a/gts-macros/src/instance.rs
+++ b/gts-macros/src/instance.rs
@@ -1,0 +1,556 @@
+//! Construction macros for GTS instances — `gts_instance!` and
+//! `gts_instance_raw!`.
+//!
+//! `gts_instance!` accepts a Rust struct literal where the GTS instance id
+//! is supplied as a string literal in the dedicated id field
+//! (`id` / `gts_id` / `gtsId` — see [`crate::ID_FIELD_NAMES`]). The macro
+//! parses the literal, validates its shape per GTS spec §2.2 / §3.7,
+//! splits it into prefix + segment, and rewrites the field's value to a
+//! `GtsInstanceId::new(prefix, segment)` call. The prefix half is then
+//! const-asserted against `<S as GtsSchema>::SCHEMA_ID` so a literal that
+//! claims to belong to a different schema fails the build.
+//!
+//! For chained schemas the const-assert target is derived from the struct
+//! literal's turbofish: the macro descends through angle-bracketed type
+//! args, picking the deepest non-generic path as the conforming type. So
+//! `BaseV1::<LeafV1> { ... }` targets `<LeafV1 as GtsSchema>::SCHEMA_ID`
+//! (the full chain), and `BaseV1::<MiddleV1<LeafV1>> { ... }` likewise
+//! targets `LeafV1`. `BaseV1::<()> { ... }` keeps the carrier itself as
+//! the target (base-level instance). For chained schemas the turbofish is
+//! mandatory — bare `BaseV1 { ... }` fails to compile because Rust needs
+//! explicit generics in trait position.
+//!
+//! `#[gts_static(NAME)]` is the only outer attribute supported: it wraps
+//! the produced value in a `pub static NAME: LazyLock<T>` binding (item
+//! form).
+//!
+//! `gts_instance_raw!` is a separate, JSON-shaped form for instances that
+//! have no Rust struct counterpart; its syntax is not affected by this
+//! file's typed-form rework.
+//!
+//! The `#[proc_macro]` entry points must live at the crate root (Rust
+//! restriction); see `lib.rs` for the thin shims that call into
+//! [`expand_gts_instance`] and [`expand_gts_instance_raw`] here.
+
+use crate::ID_FIELD_NAMES;
+use proc_macro2::TokenStream as TokenStream2;
+use quote::quote;
+use syn::parse::{Parse, ParseStream};
+use syn::punctuated::Punctuated;
+use syn::{
+    Attribute, Expr, ExprLit, ExprStruct, FieldValue, GenericArgument, Ident, Lit, LitStr, Path,
+    PathArguments, Token, Type, parse2,
+};
+
+/// Validate an `instance_id` literal against the full GTS spec via the
+/// shared `gts-id` validator. Catches malformed segments (missing
+/// `<vendor>.<package>.<namespace>.<type>.v<N>` shape, bad version
+/// suffix, etc.) at compile time with span pointing at the literal.
+fn validate_instance_id_format(instance_id: &LitStr) -> syn::Result<()> {
+    let raw = instance_id.value();
+    if let Err(e) = gts_id::validate_gts_id(&raw, false) {
+        let msg = match &e {
+            gts_id::GtsIdError::Id { cause, .. } => format!("Invalid GTS instance ID: {cause}"),
+            gts_id::GtsIdError::Segment { num, cause, .. } => {
+                format!("Invalid GTS instance ID: segment #{num}: {cause}")
+            }
+        };
+        return Err(syn::Error::new_spanned(instance_id, msg));
+    }
+    Ok(())
+}
+
+/// Split a full `instance_id` literal into `(type_id, segment)` per GTS
+/// spec §2.2 / §3.7. The id must contain at least one `~` and must not end
+/// with `~` (that form denotes a schema). `type_id` includes the trailing
+/// `~`; `segment` is everything after it. Assumes the literal is already
+/// format-validated via [`validate_instance_id_format`].
+fn split_instance_id(instance_id: &LitStr) -> syn::Result<(String, String)> {
+    let raw = instance_id.value();
+    if raw.ends_with('~') {
+        return Err(syn::Error::new_spanned(
+            instance_id,
+            "instance id literal must not end with `~` (that denotes a schema, not an instance)",
+        ));
+    }
+    let Some(last_tilde) = raw.rfind('~') else {
+        return Err(syn::Error::new_spanned(
+            instance_id,
+            "instance id literal must contain at least one `~` (chained form: gts.<type>~<instance>)",
+        ));
+    };
+    let type_id = raw[..=last_tilde].to_owned();
+    let segment = raw[last_tilde + 1..].to_owned();
+    Ok((type_id, segment))
+}
+
+/// Strip turbofish (`Foo::<T>`) from a path so it can be used in *type*
+/// position (`Foo<T>`). Used both for the const-assert target (qualified
+/// path syntax `<X as Trait>::ASSOC` requires type position) and for the
+/// `LazyLock<T>` binding when `#[gts_static(NAME)]` is given.
+fn path_for_type_position(path: &Path) -> Path {
+    let mut cloned = path.clone();
+    for seg in &mut cloned.segments {
+        if let PathArguments::AngleBracketed(args) = &mut seg.arguments {
+            args.colon2_token = None;
+        }
+    }
+    cloned
+}
+
+/// Derive the const-assert target type from the struct literal's path by
+/// recursively descending into the last angle-bracketed type argument
+/// until a path with no angle args is reached.
+///
+/// Examples (left = struct path, right = derived target):
+/// - `TopicV1`                      → `TopicV1` (no descent)
+/// - `BaseV1::<LeafV1>`             → `LeafV1`
+/// - `BaseV1::<MiddleV1<LeafV1>>`   → `LeafV1`
+/// - `BaseV1::<()>`                 → `BaseV1::<()>` (carrier kept; `()`
+///   has empty `SCHEMA_ID`, so const-assert must hit the carrier)
+///
+/// The deepest type is expected to carry `struct_to_gts_schema` (i.e.
+/// implement `GtsSchema`); if it doesn't, the emitted `<X as GtsSchema>`
+/// reference fails to typecheck — surfacing a clear error at the call
+/// site without any extra macro logic.
+fn derive_schema_target_from_path(path: &Path) -> Path {
+    let Some(last_seg) = path.segments.last() else {
+        return path.clone();
+    };
+    let PathArguments::AngleBracketed(args) = &last_seg.arguments else {
+        return path.clone();
+    };
+    let last_type_arg = args.args.iter().rev().find_map(|arg| match arg {
+        GenericArgument::Type(ty) => Some(ty),
+        _ => None,
+    });
+    match last_type_arg {
+        Some(Type::Path(type_path)) => derive_schema_target_from_path(&type_path.path),
+        // `()` and other non-path types: stop, keep the carrier (with its
+        // explicit args) as the assert target.
+        _ => path.clone(),
+    }
+}
+
+/// Parsed args for `gts_instance!`. Input shape:
+///
+/// ```text
+/// #[gts_static(StaticName)]?
+/// StructPath { id: "...", ...other fields... }
+/// ```
+struct TypedInstanceArgs {
+    /// The struct literal as the user wrote it. Mutated downstream to
+    /// rewrite the id-field's string-literal value into a
+    /// `GtsInstanceId::new(prefix, segment)` call.
+    instance: ExprStruct,
+    /// Optional binding name from `#[gts_static(NAME)]`; when set, the
+    /// macro emits a `pub static NAME: LazyLock<T>` instead of a bare
+    /// expression.
+    static_name: Option<Ident>,
+}
+
+impl Parse for TypedInstanceArgs {
+    fn parse(input: ParseStream<'_>) -> syn::Result<Self> {
+        let attrs = input.call(Attribute::parse_outer)?;
+        let mut static_name: Option<Ident> = None;
+
+        for attr in attrs {
+            if !attr.path().is_ident("gts_static") {
+                return Err(syn::Error::new_spanned(
+                    &attr,
+                    "unknown attribute on gts_instance! struct literal; expected `#[gts_static(...)]`",
+                ));
+            }
+            // Outer-style attrs only — inner (`#![...]`) doesn't make
+            // sense on a struct literal and would be confusing.
+            if matches!(attr.style, syn::AttrStyle::Inner(_)) {
+                return Err(syn::Error::new_spanned(
+                    &attr,
+                    "gts_instance! attributes must use outer style `#[...]`, not inner `#![...]`",
+                ));
+            }
+            if static_name.is_some() {
+                return Err(syn::Error::new_spanned(
+                    &attr,
+                    "duplicate `#[gts_static(...)]`",
+                ));
+            }
+            static_name = Some(attr.parse_args::<Ident>().map_err(|e| {
+                syn::Error::new(
+                    e.span(),
+                    "expected `#[gts_static(NAME)]` - an identifier for the emitted `pub static`",
+                )
+            })?);
+        }
+
+        let instance: ExprStruct = input.parse().map_err(|e| {
+            syn::Error::new(
+                e.span(),
+                "expected a struct literal: `StructPath { id: \"gts...\", ...other fields... }`",
+            )
+        })?;
+        if !input.is_empty() {
+            return Err(input.error(
+                "unexpected tokens after struct literal; gts_instance! takes a single struct literal optionally preceded by `#[gts_static(...)]`",
+            ));
+        }
+        Ok(Self {
+            instance,
+            static_name,
+        })
+    }
+}
+
+/// Locate the GTS instance-id field in the user's struct literal and
+/// extract its string-literal value. Returns the field's index in
+/// `instance.fields`, the chosen id-field identifier, and the parsed
+/// `LitStr`. Errors on missing / duplicate / non-string-literal id field
+/// with diagnostics that point at the offending span.
+fn extract_id_field(instance: &ExprStruct) -> syn::Result<(usize, Ident, LitStr)> {
+    if let Some(rest) = &instance.rest {
+        return Err(syn::Error::new_spanned(
+            rest,
+            "struct update syntax (`..rest`) is not supported; list all fields explicitly",
+        ));
+    }
+
+    let mut found: Option<(usize, Ident, LitStr)> = None;
+    for (idx, field) in instance.fields.iter().enumerate() {
+        let syn::Member::Named(ident) = &field.member else {
+            continue;
+        };
+        let name = ident.to_string();
+        if !ID_FIELD_NAMES.contains(&name.as_str()) {
+            continue;
+        }
+        if let Some((_, prev_ident, _)) = &found {
+            return Err(syn::Error::new_spanned(
+                field,
+                format!(
+                    "ambiguous id field: both `{prev_ident}` and `{name}` are reserved GTS instance-id field names; use exactly one"
+                ),
+            ));
+        }
+        let Expr::Lit(ExprLit {
+            lit: Lit::Str(lit_str),
+            ..
+        }) = &field.expr
+        else {
+            return Err(syn::Error::new_spanned(
+                &field.expr,
+                format!(
+                    "`{name}:` must be a string literal containing the full GTS instance id (e.g. \"gts.acme.core.events.topic.v1~vendor.app.x.v1\")"
+                ),
+            ));
+        };
+        found = Some((idx, ident.clone(), lit_str.clone()));
+    }
+
+    found.ok_or_else(|| {
+        syn::Error::new_spanned(
+            &instance.path,
+            format!(
+                "missing GTS instance-id field; the struct literal must contain exactly one of: {}",
+                ID_FIELD_NAMES.join(", ")
+            ),
+        )
+    })
+}
+
+/// Build the typed instance as a block expression: the struct literal
+/// with the id-field's string rewritten to `GtsInstanceId::new(...)`,
+/// preceded by a const-asserted prefix check. Validates the id literal's
+/// shape (full GTS-spec format + `~` rules) and rejects struct-update
+/// syntax (`..rest`) and missing/ambiguous/non-literal id fields.
+fn build_typed_instance_block(args: &TypedInstanceArgs) -> syn::Result<TokenStream2> {
+    let (id_idx, id_ident, instance_id_lit) = extract_id_field(&args.instance)?;
+    validate_instance_id_format(&instance_id_lit)?;
+    let (prefix_str, segment_str) = split_instance_id(&instance_id_lit)?;
+    let prefix_lit = LitStr::new(&prefix_str, instance_id_lit.span());
+    let segment_lit = LitStr::new(&segment_str, instance_id_lit.span());
+
+    // Replace the id field's string literal with a GtsInstanceId::new call.
+    let mut struct_expr = args.instance.clone();
+    let new_field: FieldValue = syn::parse_quote! {
+        #id_ident: ::gts::GtsInstanceId::new(#prefix_lit, #segment_lit)
+    };
+    let mut new_fields: Punctuated<FieldValue, Token![,]> = Punctuated::new();
+    for (idx, field) in struct_expr.fields.iter().enumerate() {
+        if idx == id_idx {
+            new_fields.push(new_field.clone());
+        } else {
+            new_fields.push(field.clone());
+        }
+    }
+    struct_expr.fields = new_fields;
+
+    // The const-assert target type is derived from the struct literal's
+    // path: descend through angle args to the deepest non-generic type
+    // (the conforming schema in chained generics). For non-generic
+    // carriers the path is used as-is. Turbofish is stripped so the path
+    // is valid in `<X as Trait>` type position.
+    let schema_path = path_for_type_position(&derive_schema_target_from_path(&args.instance.path));
+
+    Ok(quote! {
+        {
+            const _: () = {
+                const fn __gts_validate_id_prefix(id: &str, schema: &str) -> bool {
+                    let id_b = id.as_bytes();
+                    let s_b = schema.as_bytes();
+                    // schema_id must end with `~`.
+                    if s_b.is_empty() || s_b[s_b.len() - 1] != b'~' {
+                        return false;
+                    }
+                    // instance_id must extend the schema by at least one byte.
+                    if id_b.len() <= s_b.len() {
+                        return false;
+                    }
+                    // Prefix must match exactly.
+                    let mut i = 0;
+                    while i < s_b.len() {
+                        if id_b[i] != s_b[i] {
+                            return false;
+                        }
+                        i += 1;
+                    }
+                    // The remainder (segment) must not contain `~`.
+                    let mut j = s_b.len();
+                    while j < id_b.len() {
+                        if id_b[j] == b'~' {
+                            return false;
+                        }
+                        j += 1;
+                    }
+                    true
+                }
+                assert!(
+                    __gts_validate_id_prefix(
+                        #instance_id_lit,
+                        <#schema_path as ::gts::GtsSchema>::SCHEMA_ID,
+                    ),
+                    "instance id literal must equal the type's GtsSchema::SCHEMA_ID followed by a single non-empty segment (no extra `~`); for chained schemas, write the full type as a turbofish on the struct literal (e.g. `BaseV1::<LeafV1>` rather than bare `BaseV1`) so the macro can derive the conforming schema"
+                );
+            };
+            #struct_expr
+        }
+    })
+}
+
+/// Implementation of the typed [`gts_instance!`] macro. The proc-macro
+/// entry point in `lib.rs` is a thin shim around this function.
+pub fn expand_gts_instance(input: TokenStream2) -> syn::Result<TokenStream2> {
+    let args: TypedInstanceArgs = parse2(input)?;
+    let block_expr = build_typed_instance_block(&args)?;
+
+    if let Some(name) = &args.static_name {
+        let type_path = path_for_type_position(&args.instance.path);
+        Ok(quote! {
+            #[allow(non_upper_case_globals)]
+            pub static #name: ::std::sync::LazyLock<#type_path> =
+                ::std::sync::LazyLock::new(|| #block_expr);
+        })
+    } else {
+        Ok(block_expr)
+    }
+}
+
+/// One key:value entry inside a `gts_instance_raw!` JSON object literal.
+/// Keys must be string literals (JSON-shape); values are captured as raw
+/// token streams so that nested objects, arrays, and arbitrary expressions
+/// pass through to `serde_json::json!` unchanged. Top-level entries are
+/// separated by `,` — `Group` token trees are atomic, so commas inside
+/// nested `{}` / `[]` / `()` are not visible at the top level and don't
+/// interfere with this loop.
+struct JsonEntry {
+    key: LitStr,
+    value: TokenStream2,
+}
+
+impl Parse for JsonEntry {
+    fn parse(input: ParseStream<'_>) -> syn::Result<Self> {
+        let key: LitStr = input.parse().map_err(|e| {
+            syn::Error::new(
+                e.span(),
+                "expected a JSON-style string-literal key (e.g. \"id\", \"name\")",
+            )
+        })?;
+        let _: Token![:] = input.parse()?;
+        let mut value = TokenStream2::new();
+        while !input.is_empty() && !input.peek(Token![,]) {
+            let tt: proc_macro2::TokenTree = input.parse()?;
+            value.extend(std::iter::once(tt));
+        }
+        Ok(Self { key, value })
+    }
+}
+
+/// Args for [`gts_instance_raw!`]. The macro takes a single brace-delimited
+/// JSON object literal where one of the top-level keys is `"id"` carrying
+/// a string-literal value. The id is extracted at proc-macro time for
+/// validation; the entire body is also spliced into a runtime
+/// `serde_json::json!({ ... })` call (the macro then unconditionally
+/// overwrites the `"id"` slot at runtime so the validated literal stays
+/// authoritative even if the body is re-edited).
+struct RawInstanceArgs {
+    instance_id: LitStr,
+    body: TokenStream2,
+}
+
+impl Parse for RawInstanceArgs {
+    fn parse(input: ParseStream<'_>) -> syn::Result<Self> {
+        // Outer braces are required: gts_instance_raw!({ "id": "...", ... })
+        let content;
+        syn::braced!(content in input);
+        if !input.is_empty() {
+            return Err(input.error(
+                "unexpected tokens after JSON object literal; gts_instance_raw! takes a single `{ ... }` body",
+            ));
+        }
+        // Capture the original body as a token stream for json! splicing.
+        let body: TokenStream2 = content.fork().parse()?;
+        // Re-parse the same content as a list of JSON entries so we can
+        // walk top-level keys.
+        let entries: Punctuated<JsonEntry, Token![,]> = Punctuated::parse_terminated(&content)?;
+
+        let mut found_id: Option<LitStr> = None;
+        for entry in &entries {
+            if entry.key.value() != "id" {
+                continue;
+            }
+            if let Some(prev) = &found_id {
+                let mut err = syn::Error::new_spanned(
+                    &entry.key,
+                    "duplicate top-level `\"id\"` key in gts_instance_raw! body",
+                );
+                err.combine(syn::Error::new_spanned(prev, "first `\"id\"` key was here"));
+                return Err(err);
+            }
+            let id_lit: LitStr = parse2(entry.value.clone()).map_err(|_| {
+                syn::Error::new_spanned(
+                    &entry.value,
+                    "`\"id\"` must be a string literal containing the full GTS instance id (e.g. \"gts.acme.core.events.topic.v1~vendor.app.x.v1\")",
+                )
+            })?;
+            found_id = Some(id_lit);
+        }
+
+        let instance_id = found_id.ok_or_else(|| {
+            syn::Error::new(
+                proc_macro2::Span::call_site(),
+                "missing top-level `\"id\"` key in gts_instance_raw! body; the JSON object must contain `\"id\": \"<full GTS instance id>\"`",
+            )
+        })?;
+
+        Ok(Self { instance_id, body })
+    }
+}
+
+/// Implementation of the raw-JSON [`gts_instance_raw!`] macro. The
+/// proc-macro entry point in `lib.rs` is a thin shim around this function.
+pub fn expand_gts_instance_raw(input: TokenStream2) -> syn::Result<TokenStream2> {
+    let args: RawInstanceArgs = parse2(input)?;
+    // Full GTS-spec format check + `~` rules. Both produce span-anchored
+    // syn errors pointing at the bad literal. The split's return value is
+    // unused; we splice the original literal into the generated JSON.
+    validate_instance_id_format(&args.instance_id)?;
+    let _ = split_instance_id(&args.instance_id)?;
+    let instance_id_lit = &args.instance_id;
+    let body_tokens = &args.body;
+    // Build the JSON object first, then unconditionally overwrite the
+    // `"id"` key with the validated literal. The user's body already
+    // contains an `"id"` entry (we rejected the macro otherwise), and
+    // serde_json's `json!` lets the later key win on duplicates — but
+    // we don't rely on that ordering. The runtime `insert` makes the
+    // validated literal authoritative regardless of what's in the body.
+    Ok(quote! {
+        {
+            let mut __gts_value = ::serde_json::json!({ #body_tokens });
+            __gts_value
+                .as_object_mut()
+                .expect("gts_instance_raw! body must be a JSON object")
+                .insert(
+                    "id".to_owned(),
+                    ::serde_json::Value::String((#instance_id_lit).to_owned()),
+                );
+            __gts_value
+        }
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    //! Unit tests for the syntactic descent in
+    //! [`derive_schema_target_from_path`]. These exercise paths that
+    //! `struct_to_gts_schema` itself can't produce (multi-param carriers,
+    //! lifetimes, const generics) — useful both as documentation of the
+    //! algorithm's contract and as a safety net for any future loosening
+    //! of the macro's single-type-param restriction.
+
+    use super::derive_schema_target_from_path;
+    use quote::quote;
+    use syn::{Path, parse2};
+
+    fn parse_path(tokens: proc_macro2::TokenStream) -> Path {
+        parse2(tokens).expect("valid path tokens")
+    }
+
+    fn render(p: &Path) -> String {
+        quote!(#p).to_string()
+    }
+
+    #[test]
+    fn descent_picks_last_type_arg_when_first_is_non_gts() {
+        // `L1OuterV1<T, L3LeafV1>` — `T` (non-GTS) is first, the GTS
+        // chain leaf is last. The descent rule is "last type arg", so
+        // the target is `L3LeafV1` regardless of `T`'s nature. If `T`
+        // happened to be the GTS one and `L3LeafV1` were last but not
+        // schema-bearing, the const-assert would fail at typecheck (as
+        // a deliberate signal — the caller wrote the wrong arg order).
+        let path = parse_path(quote!(L1OuterV1<T, L3LeafV1>));
+        let target = derive_schema_target_from_path(&path);
+        assert_eq!(render(&target), "L3LeafV1");
+    }
+
+    #[test]
+    fn descent_picks_last_through_nested_multi_param() {
+        // `Outer<T, Mid<U, Leaf>>` — descent: Outer → last arg is
+        // `Mid<U, Leaf>`, recurse → last arg is `Leaf`, no angle args →
+        // stop. `T` and `U` are ignored at every level because they are
+        // not the final type-position arg.
+        let path = parse_path(quote!(Outer<T, Mid<U, Leaf>>));
+        let target = derive_schema_target_from_path(&path);
+        assert_eq!(render(&target), "Leaf");
+    }
+
+    #[test]
+    fn descent_skips_lifetime_args() {
+        // `Carrier<'a, Leaf>` — `find_map` over reversed args picks the
+        // last `Type` arg, ignoring lifetime args entirely.
+        let path = parse_path(quote!(Carrier<'a, Leaf>));
+        let target = derive_schema_target_from_path(&path);
+        assert_eq!(render(&target), "Leaf");
+    }
+
+    #[test]
+    fn descent_keeps_carrier_when_last_is_unit_type() {
+        // `BaseV1<()>` — the descent stops on `()` (a `Type::Tuple`,
+        // not `Type::Path`) and the carrier with explicit args is
+        // kept. This is the base-instance case: `()::SCHEMA_ID = ""`,
+        // so falling back to the carrier hits the right target.
+        let path = parse_path(quote!(BaseV1<()>));
+        let target = derive_schema_target_from_path(&path);
+        // Comparing rendered tokens because syn::Path doesn't impl
+        // PartialEq.
+        assert_eq!(render(&target), render(&path));
+    }
+
+    #[test]
+    fn descent_handles_const_generic_only() {
+        // `Buf<N>` where `N` is a const generic — there's no Type arg,
+        // so the descent finds nothing to recurse into and keeps the
+        // carrier unchanged.
+        let path = parse_path(quote!(Buf<{ 4 }>));
+        let target = derive_schema_target_from_path(&path);
+        assert_eq!(render(&target), render(&path));
+    }
+}

--- a/gts-macros/src/lib.rs
+++ b/gts-macros/src/lib.rs
@@ -346,8 +346,7 @@ fn has_derive(input: &syn::DeriveInput, trait_name: &str) -> bool {
             && attr
                 .meta
                 .require_list()
-                .map(|meta| meta.tokens.to_string().contains(trait_name))
-                .unwrap_or(false)
+                .is_ok_and(|meta| meta.tokens.to_string().contains(trait_name))
     })
 }
 

--- a/gts-macros/src/lib.rs
+++ b/gts-macros/src/lib.rs
@@ -339,14 +339,24 @@ fn validate_version_match(struct_ident: &syn::Ident, schema_id: &str) -> syn::Re
     }
 }
 
-/// Check if a derive attribute contains a specific trait name
+/// Check if the input has a bare `#[derive(...)]` listing `trait_name` exactly.
+///
+/// Compares each derive entry's last path segment ident against `trait_name`,
+/// so `#[derive(MyJsonSchema)]` does NOT match `JsonSchema` and
+/// `#[derive(SerializeIfPresent)]` does NOT match `Serialize`. Path prefixes
+/// are stripped (`serde::Serialize` matches `Serialize`). `cfg_attr`-wrapped
+/// derives are intentionally not consulted here — the callers (`add_missing_derives`)
+/// auto-add unconditional derives, and a conditional derive is treated as
+/// "not present" for the unconditional case.
 fn has_derive(input: &syn::DeriveInput, trait_name: &str) -> bool {
     input.attrs.iter().any(|attr| {
         attr.path().is_ident("derive")
             && attr
                 .meta
                 .require_list()
-                .is_ok_and(|meta| meta.tokens.to_string().contains(trait_name))
+                .ok()
+                .and_then(|meta| syn::parse2::<DeriveList>(meta.tokens.clone()).ok())
+                .is_some_and(|DeriveList(derives)| derive_list_contains(&derives, trait_name))
     })
 }
 
@@ -1838,4 +1848,162 @@ pub fn struct_to_gts_schema(attr: TokenStream, item: TokenStream) -> TokenStream
     };
 
     TokenStream::from(expanded)
+}
+
+// =====================================================================
+//             gts_instance! / gts_instance_raw!
+// =====================================================================
+//
+// Implementation lives in `instance.rs`. The `#[proc_macro]` entry
+// points must live at the crate root (Rust restriction), so they are
+// thin shims here that delegate into the module.
+
+mod instance;
+
+/// Typed GTS instance.
+///
+/// The macro takes a Rust struct literal and rewrites the GTS instance-id
+/// field's string-literal value into a `GtsInstanceId::new(prefix, segment)`
+/// call after compile-time validation. The id field is one of `id` /
+/// `gts_id` / `gtsId` — whichever your `#[struct_to_gts_schema]`-generated
+/// type uses; the macro picks the matching name automatically.
+///
+/// ## Expression form (default)
+///
+/// ```ignore
+/// let t: TopicV1 = gts_macros::gts_instance!(TopicV1 {
+///     id: "gts.acme.core.events.topic.v1~vendor.app.orders.created.v1",
+///     name: "orders".to_owned(),
+///     retention: "P30D".to_owned(),
+/// });
+/// ```
+///
+/// The literal is validated against `gts_id::validate_gts_id` and
+/// const-asserted to share its prefix with `<TopicV1 as GtsSchema>::SCHEMA_ID`.
+/// The id field's apparent string value is rewritten by the macro — at
+/// runtime `t.id` is a `GtsInstanceId`, not a `String`.
+///
+/// ## Chained generic carriers — turbofish drives the prefix-assert
+///
+/// For chained schemas, write the conforming type as a turbofish on the
+/// struct literal. The macro descends through angle args to the deepest
+/// non-generic path and uses that as the const-assert target — so the
+/// literal's prefix is matched against the full chain's schema id, not
+/// the bare carrier's:
+///
+/// ```ignore
+/// let v: BaseV1<LeafV1> = gts_macros::gts_instance!(BaseV1::<LeafV1> {
+///     id: "gts.acme.core.test.base.v1~acme.core.test.leaf.v1~vendor.app.example.v1",
+///     payload: LeafV1 { name: "ex".to_owned() },
+/// });
+/// ```
+///
+/// `BaseV1::<()> { ... }` keeps the carrier itself as the target (a
+/// base-level instance). Bare `BaseV1 { ... }` (no turbofish on a generic
+/// carrier) is rejected — Rust requires explicit generics in the trait
+/// position the macro emits, and the turbofish is the only signal the
+/// macro has for picking the conforming type.
+///
+/// ## `#[gts_static(NAME)]` — emit a `pub static LazyLock<T>` binding
+///
+/// In item position, the macro can additionally wrap the produced value
+/// in a lazily-initialised static binding so that other modules can
+/// reference it by name without going through JSON:
+///
+/// ```ignore
+/// gts_macros::gts_instance! {
+///     #[gts_static(ORDERS_TOPIC)]
+///     TopicV1 {
+///         id: "gts.acme.core.events.topic.v1~vendor.app.orders.created.v1",
+///         name: "orders".to_owned(),
+///         retention: "P30D".to_owned(),
+///     }
+/// }
+///
+/// // Elsewhere — typed access by name, no JSON round-trip:
+/// let t: &TopicV1 = &ORDERS_TOPIC;
+/// ```
+///
+/// `#[gts_static(NAME)]` is the only outer attribute the macro accepts;
+/// other attributes are rejected with a span-anchored error.
+///
+/// ## What you don't need `#[gts_static]` for
+///
+/// Adding an instance to a JSON-shaped runtime registry (e.g.
+/// `inventory::submit!`) doesn't need a static — pass the bare expression
+/// form into a closure:
+///
+/// ```ignore
+/// inventory::submit! {
+///     MyEntry {
+///         payload_fn: || ::serde_json::to_value(
+///             &gts_macros::gts_instance!(T { id: "gts....", /* ... */ })
+///         ).unwrap(),
+///     }
+/// }
+/// ```
+///
+/// Reach for `#[gts_static(NAME)]` when the *typed value itself* (not a
+/// JSON projection of it) needs to be addressable elsewhere in the
+/// program.
+///
+/// ## Errors
+///
+/// - Missing id field in the literal: `the struct literal must contain
+///   exactly one of: id, gts_id, gtsId`.
+/// - Two id fields (`id:` and `gts_id:` together): `ambiguous id field`.
+/// - Non-literal id value (`id: some_var`): `must be a string literal`.
+/// - Malformed id literal: full error from `gts_id::validate_gts_id`.
+/// - Schema-prefix mismatch: const-assert fails at build time.
+/// - `..rest` struct update syntax: not supported.
+///
+/// For raw-JSON payloads, see [`gts_instance_raw!`].
+#[proc_macro]
+pub fn gts_instance(input: TokenStream) -> TokenStream {
+    match instance::expand_gts_instance(input.into()) {
+        Ok(tokens) => tokens.into(),
+        Err(e) => e.to_compile_error().into(),
+    }
+}
+
+/// Raw-JSON GTS instance, expression form. Use when the instance does
+/// not correspond to a Rust struct.
+///
+/// The macro takes a single JSON object literal where one top-level key
+/// is `"id"` carrying a string-literal value. The id is validated at
+/// proc-macro time (full GTS spec format + chained-form rules) and the
+/// resulting `serde_json::Value` always has the validated literal in its
+/// `"id"` slot — even if the original body is later edited to disagree.
+///
+/// ```ignore
+/// let v: serde_json::Value = gts_macros::gts_instance_raw!({
+///     "id": "gts.acme.core.events.topic.v1~vendor.app.events.audit.v1",
+///     "name": "audit",
+///     "description": "Audit log events",
+/// });
+/// ```
+///
+/// Other top-level keys, nested objects, and arrays pass through to
+/// `serde_json::json!` unchanged. The macro only inspects the top-level
+/// `"id"` key — nested `"id"` fields inside sub-objects are payload data,
+/// not the instance identifier.
+///
+/// ## Errors
+///
+/// - Missing top-level `"id"`: `missing top-level "id" key`.
+/// - Duplicate top-level `"id"`: pointed at both spans.
+/// - Non-literal `"id"` value: `"id" must be a string literal`.
+/// - Malformed id literal: full error from `gts_id::validate_gts_id`.
+/// - Body missing chained `~`: `instance id literal must contain at
+///   least one ~`.
+///
+/// The macro intentionally gives up compile-time field validation against
+/// any schema; payload validation is the responsibility of the caller's
+/// runtime registry.
+#[proc_macro]
+pub fn gts_instance_raw(input: TokenStream) -> TokenStream {
+    match instance::expand_gts_instance_raw(input.into()) {
+        Ok(tokens) => tokens.into(),
+        Err(e) => e.to_compile_error().into(),
+    }
 }

--- a/gts-macros/tests/compile_fail/base_parent_mismatch.stderr
+++ b/gts-macros/tests/compile_fail/base_parent_mismatch.stderr
@@ -3,9 +3,3 @@ error: struct_to_gts_schema: Base structs must have either an ID field (one of: 
    |
 15 | pub struct BaseEventV1<P> {
    |            ^^^^^^^^^^^
-
-error[E0412]: cannot find type `BaseEventV1` in this scope
-  --> tests/compile_fail/base_parent_mismatch.rs:25:12
-   |
-25 |     base = BaseEventV1,
-   |            ^^^^^^^^^^^ not found in this scope

--- a/gts-macros/tests/compile_fail/instance_chained_carrier_no_turbofish.rs
+++ b/gts-macros/tests/compile_fail/instance_chained_carrier_no_turbofish.rs
@@ -1,0 +1,44 @@
+//! Test: typed `gts_instance!` rejects a struct literal that omits the
+//! turbofish on a generic carrier (`BaseV1 { ... }` instead of
+//! `BaseV1::<LeafV1> { ... }`). The macro emits
+//! `<BaseV1 as GtsSchema>::SCHEMA_ID`, which fails because `BaseV1` is
+//! generic and Rust requires explicit generics in trait position. The
+//! turbofish is the macro's only signal for deriving the conforming
+//! schema in chained carriers, so it is mandatory.
+
+use gts::GtsInstanceId;
+use gts_macros::{gts_instance, struct_to_gts_schema};
+
+#[struct_to_gts_schema(
+    dir_path = "schemas",
+    base = true,
+    schema_id = "gts.acme.core.test.base.v1~",
+    description = "Generic base type for compile_fail/instance_chained_carrier_no_turbofish",
+    properties = "id,payload"
+)]
+#[derive(Debug)]
+pub struct BaseV1<P> {
+    pub id: GtsInstanceId,
+    pub payload: P,
+}
+
+#[struct_to_gts_schema(
+    dir_path = "schemas",
+    base = BaseV1,
+    schema_id = "gts.acme.core.test.base.v1~acme.core.test.leaf.v1~",
+    description = "Derived leaf type for compile_fail/instance_chained_carrier_no_turbofish",
+    properties = "name"
+)]
+#[derive(Debug)]
+pub struct LeafV1 {
+    pub name: String,
+}
+
+fn main() {
+    let _v: BaseV1<LeafV1> = gts_instance! {
+        BaseV1 {
+            id: "gts.acme.core.test.base.v1~vendor.app.things.bare.v1",
+            payload: LeafV1 { name: "ex".to_owned() },
+        }
+    };
+}

--- a/gts-macros/tests/compile_fail/instance_chained_carrier_no_turbofish.stderr
+++ b/gts-macros/tests/compile_fail/instance_chained_carrier_no_turbofish.stderr
@@ -1,0 +1,15 @@
+error[E0107]: missing generics for struct `BaseV1`
+  --> tests/compile_fail/instance_chained_carrier_no_turbofish.rs:39:9
+   |
+39 |         BaseV1 {
+   |         ^^^^^^ expected 1 generic argument
+   |
+note: struct defined here, with 1 generic parameter: `P`
+  --> tests/compile_fail/instance_chained_carrier_no_turbofish.rs:20:12
+   |
+20 | pub struct BaseV1<P> {
+   |            ^^^^^^ -
+help: add missing generic argument
+   |
+39 |         BaseV1<P> {
+   |               +++

--- a/gts-macros/tests/compile_fail/instance_derived_target_id_mismatch.rs
+++ b/gts-macros/tests/compile_fail/instance_derived_target_id_mismatch.rs
@@ -1,0 +1,51 @@
+//! Test: typed `gts_instance!` rejects a chained generic carrier whose
+//! turbofish-derived target's `SCHEMA_ID` is not the direct parent of
+//! the `id:` literal. Here the carrier is `BaseV1::<LeafV1>`, so the
+//! macro derives `LeafV1` as the const-assert target — but the literal
+//! is a base-level id (only one segment past `BaseV1::SCHEMA_ID`), not
+//! a leaf-level id. `<LeafV1 as GtsSchema>::SCHEMA_ID` is therefore not
+//! a prefix of the literal, and the const-assert rejects.
+//! Fixture is built via `#[struct_to_gts_schema]` to match the canonical
+//! usage pattern.
+
+use gts::GtsInstanceId;
+use gts_macros::{gts_instance, struct_to_gts_schema};
+
+#[struct_to_gts_schema(
+    dir_path = "schemas",
+    base = true,
+    schema_id = "gts.acme.core.test.base.v1~",
+    description = "Generic base type for compile_fail/instance_derived_target_id_mismatch",
+    properties = "id,payload"
+)]
+#[derive(Debug)]
+pub struct BaseV1<P> {
+    pub id: GtsInstanceId,
+    pub payload: P,
+}
+
+#[struct_to_gts_schema(
+    dir_path = "schemas",
+    base = BaseV1,
+    schema_id = "gts.acme.core.test.base.v1~acme.core.test.leaf.v1~",
+    description = "Derived leaf type for compile_fail/instance_derived_target_id_mismatch",
+    properties = "name"
+)]
+#[derive(Debug)]
+pub struct LeafV1 {
+    pub name: String,
+}
+
+fn main() {
+    // Turbofish carrier `BaseV1::<LeafV1>` makes the macro derive the
+    // const-assert target as `LeafV1`. The literal below is a base-level
+    // instance id (single segment past `BaseV1::SCHEMA_ID`), so the
+    // derived target's `SCHEMA_ID` is not a direct parent of the
+    // literal — the const-assert prefix check rejects.
+    let _v: BaseV1<LeafV1> = gts_instance!(BaseV1::<LeafV1> {
+        id: "gts.acme.core.test.base.v1~vendor.app.things.bare.v1",
+        payload: LeafV1 {
+            name: "ex".to_owned()
+        },
+    });
+}

--- a/gts-macros/tests/compile_fail/instance_derived_target_id_mismatch.stderr
+++ b/gts-macros/tests/compile_fail/instance_derived_target_id_mismatch.stderr
@@ -1,0 +1,11 @@
+error[E0080]: evaluation panicked: instance id literal must equal the type's GtsSchema::SCHEMA_ID followed by a single non-empty segment (no extra `~`); for chained schemas, write the full type as a turbofish on the struct literal (e.g. `BaseV1::<LeafV1>` rather than bare `BaseV1`) so the macro can derive the conforming schema
+  --> tests/compile_fail/instance_derived_target_id_mismatch.rs:45:30
+   |
+45 |       let _v: BaseV1<LeafV1> = gts_instance!(BaseV1::<LeafV1> {
+   |  ______________________________^
+46 | |         id: "gts.acme.core.test.base.v1~vendor.app.things.bare.v1",
+47 | |         payload: LeafV1 {
+48 | |             name: "ex".to_owned()
+49 | |         },
+50 | |     });
+   | |______^ evaluation of `main::_` failed here

--- a/gts-macros/tests/compile_fail/instance_id_invalid_format.rs
+++ b/gts-macros/tests/compile_fail/instance_id_invalid_format.rs
@@ -1,0 +1,29 @@
+//! Test: typed `gts_instance!` rejects a malformed id literal at
+//! proc-macro time via the shared `gts_id::validate_gts_id`. Catches
+//! issues like a missing `<vendor>.<package>.<namespace>.<type>.v<N>`
+//! segment shape before any further checks.
+
+use gts::GtsInstanceId;
+use gts_macros::{gts_instance, struct_to_gts_schema};
+
+#[struct_to_gts_schema(
+    dir_path = "schemas",
+    base = true,
+    schema_id = "gts.acme.core.test.perm.v1~",
+    description = "Test permission type for compile_fail/instance_id_invalid_format",
+    properties = "id,action"
+)]
+#[derive(Debug)]
+pub struct PermV1 {
+    pub id: GtsInstanceId,
+    pub action: String,
+}
+
+fn main() {
+    // Segment after `~` is missing a version suffix and has fewer
+    // dot-tokens than the GTS spec requires.
+    let _ = gts_instance!(PermV1 {
+        id: "gts.acme.core.test.perm.v1~not.a.valid.segment",
+        action: "read".to_owned(),
+    });
+}

--- a/gts-macros/tests/compile_fail/instance_id_invalid_format.stderr
+++ b/gts-macros/tests/compile_fail/instance_id_invalid_format.stderr
@@ -1,0 +1,5 @@
+error: Invalid GTS instance ID: segment #2: Too few tokens (got 4, min 5). Expected format: vendor.package.namespace.type.vMAJOR[.MINOR]
+  --> tests/compile_fail/instance_id_invalid_format.rs:26:13
+   |
+26 |         id: "gts.acme.core.test.perm.v1~not.a.valid.segment",
+   |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/gts-macros/tests/compile_fail/instance_id_not_literal.rs
+++ b/gts-macros/tests/compile_fail/instance_id_not_literal.rs
@@ -1,0 +1,27 @@
+//! Test: typed `gts_instance!` rejects an `id:` field whose value isn't
+//! a string literal. The macro needs to validate the GTS id shape and
+//! split it at compile time, so a runtime expression can't be used.
+
+use gts::GtsInstanceId;
+use gts_macros::{gts_instance, struct_to_gts_schema};
+
+#[struct_to_gts_schema(
+    dir_path = "schemas",
+    base = true,
+    schema_id = "gts.acme.core.test.perm.v1~",
+    description = "Test permission type for compile_fail/instance_id_not_literal",
+    properties = "id,action"
+)]
+#[derive(Debug)]
+pub struct PermV1 {
+    pub id: GtsInstanceId,
+    pub action: String,
+}
+
+fn main() {
+    let runtime_id = "gts.acme.core.test.perm.v1~vendor.app.test.x.v1".to_owned();
+    let _ = gts_instance!(PermV1 {
+        id: runtime_id,
+        action: "read".to_owned(),
+    });
+}

--- a/gts-macros/tests/compile_fail/instance_id_not_literal.stderr
+++ b/gts-macros/tests/compile_fail/instance_id_not_literal.stderr
@@ -1,0 +1,5 @@
+error: `id:` must be a string literal containing the full GTS instance id (e.g. "gts.acme.core.events.topic.v1~vendor.app.x.v1")
+  --> tests/compile_fail/instance_id_not_literal.rs:24:13
+   |
+24 |         id: runtime_id,
+   |             ^^^^^^^^^^

--- a/gts-macros/tests/compile_fail/instance_id_prefix_mismatch.rs
+++ b/gts-macros/tests/compile_fail/instance_id_prefix_mismatch.rs
@@ -1,0 +1,29 @@
+//! Test: typed `gts_instance!` rejects an `id:` literal whose prefix
+//! doesn't match the type's `<S as GtsSchema>::SCHEMA_ID`. The check
+//! fires at compile time via the const-assert in the macro expansion.
+//! Fixture is built via `#[struct_to_gts_schema]` to match the canonical
+//! usage pattern.
+
+use gts::GtsInstanceId;
+use gts_macros::{gts_instance, struct_to_gts_schema};
+
+#[struct_to_gts_schema(
+    dir_path = "schemas",
+    base = true,
+    schema_id = "gts.acme.core.test.perm.v1~",
+    description = "Test permission type for compile_fail/instance_id_prefix_mismatch",
+    properties = "id,action"
+)]
+#[derive(Debug)]
+pub struct PermV1 {
+    pub id: GtsInstanceId,
+    pub action: String,
+}
+
+fn main() {
+    // Format-valid id, but the prefix does not match `PermV1::SCHEMA_ID`.
+    let _ = gts_instance!(PermV1 {
+        id: "gts.zzz.core.other.thing.v1~vendor.app.test.x.v1",
+        action: "read".to_owned(),
+    });
+}

--- a/gts-macros/tests/compile_fail/instance_id_prefix_mismatch.stderr
+++ b/gts-macros/tests/compile_fail/instance_id_prefix_mismatch.stderr
@@ -1,0 +1,9 @@
+error[E0080]: evaluation panicked: instance id literal must equal the type's GtsSchema::SCHEMA_ID followed by a single non-empty segment (no extra `~`); for chained schemas, write the full type as a turbofish on the struct literal (e.g. `BaseV1::<LeafV1>` rather than bare `BaseV1`) so the macro can derive the conforming schema
+  --> tests/compile_fail/instance_id_prefix_mismatch.rs:25:13
+   |
+25 |       let _ = gts_instance!(PermV1 {
+   |  _____________^
+26 | |         id: "gts.zzz.core.other.thing.v1~vendor.app.test.x.v1",
+27 | |         action: "read".to_owned(),
+28 | |     });
+   | |______^ evaluation of `main::_` failed here

--- a/gts-macros/tests/compile_fail/instance_id_too_deep.rs
+++ b/gts-macros/tests/compile_fail/instance_id_too_deep.rs
@@ -1,0 +1,34 @@
+//! Test: typed `gts_instance!` rejects an `id:` literal whose segment
+//! contains additional `~` separators (i.e. the literal denotes a deeper
+//! schema chain than the type's `SCHEMA_ID`). For chained schemas the
+//! caller must use a generic carrier with the conforming type as a
+//! turbofish parameter (`BaseV1::<LeafV1> { ... }`); a non-generic
+//! carrier like `PermV1` cannot legitimately produce a deeper id.
+//! Fixture is built via `#[struct_to_gts_schema]` to match the canonical
+//! usage pattern.
+
+use gts::GtsInstanceId;
+use gts_macros::{gts_instance, struct_to_gts_schema};
+
+#[struct_to_gts_schema(
+    dir_path = "schemas",
+    base = true,
+    schema_id = "gts.acme.core.test.perm.v1~",
+    description = "Test permission type for compile_fail/instance_id_too_deep",
+    properties = "id,action"
+)]
+#[derive(Debug)]
+pub struct PermV1 {
+    pub id: GtsInstanceId,
+    pub action: String,
+}
+
+fn main() {
+    // Prefix matches SCHEMA_ID, but the literal continues with another
+    // `~`-separated segment, implying a deeper schema. The const-assert
+    // rejects (no turbofish path is available — `PermV1` is non-generic).
+    let _ = gts_instance!(PermV1 {
+        id: "gts.acme.core.test.perm.v1~vendor.app.test.deeper.v1~vendor.app.test.leaf.v1",
+        action: "read".to_owned(),
+    });
+}

--- a/gts-macros/tests/compile_fail/instance_id_too_deep.stderr
+++ b/gts-macros/tests/compile_fail/instance_id_too_deep.stderr
@@ -1,0 +1,9 @@
+error[E0080]: evaluation panicked: instance id literal must equal the type's GtsSchema::SCHEMA_ID followed by a single non-empty segment (no extra `~`); for chained schemas, write the full type as a turbofish on the struct literal (e.g. `BaseV1::<LeafV1>` rather than bare `BaseV1`) so the macro can derive the conforming schema
+  --> tests/compile_fail/instance_id_too_deep.rs:30:13
+   |
+30 |       let _ = gts_instance!(PermV1 {
+   |  _____________^
+31 | |         id: "gts.acme.core.test.perm.v1~vendor.app.test.deeper.v1~vendor.app.test.leaf.v1",
+32 | |         action: "read".to_owned(),
+33 | |     });
+   | |______^ evaluation of `main::_` failed here

--- a/gts-macros/tests/compile_fail/instance_id_wildcard_in_instance.rs
+++ b/gts-macros/tests/compile_fail/instance_id_wildcard_in_instance.rs
@@ -1,0 +1,28 @@
+//! Test: typed `gts_instance!` rejects an id literal containing a
+//! wildcard (`*`). Wildcards are valid only in pattern-matching contexts
+//! (`<schema>~*` for "any instance of this type"), never in concrete
+//! instance ids — `validate_gts_id(_, allow_wildcards=false)` enforces
+//! this at proc-macro time.
+
+use gts::GtsInstanceId;
+use gts_macros::{gts_instance, struct_to_gts_schema};
+
+#[struct_to_gts_schema(
+    dir_path = "schemas",
+    base = true,
+    schema_id = "gts.acme.core.test.perm.v1~",
+    description = "Test permission type for compile_fail/instance_id_wildcard_in_instance",
+    properties = "id,action"
+)]
+#[derive(Debug)]
+pub struct PermV1 {
+    pub id: GtsInstanceId,
+    pub action: String,
+}
+
+fn main() {
+    let _ = gts_instance!(PermV1 {
+        id: "gts.acme.core.test.perm.v1~vendor.*.test.x.v1",
+        action: "read".to_owned(),
+    });
+}

--- a/gts-macros/tests/compile_fail/instance_id_wildcard_in_instance.stderr
+++ b/gts-macros/tests/compile_fail/instance_id_wildcard_in_instance.stderr
@@ -1,0 +1,5 @@
+error: Invalid GTS instance ID: segment #2: Invalid package token '*'. Must start with [a-z_] and contain only [a-z0-9_]
+  --> tests/compile_fail/instance_id_wildcard_in_instance.rs:25:13
+   |
+25 |         id: "gts.acme.core.test.perm.v1~vendor.*.test.x.v1",
+   |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/gts-macros/tests/compile_fail/instance_missing_id.rs
+++ b/gts-macros/tests/compile_fail/instance_missing_id.rs
@@ -1,0 +1,25 @@
+//! Test: typed `gts_instance!` rejects a struct literal that has no
+//! GTS instance-id field at all. The macro requires exactly one of
+//! `id` / `gts_id` / `gtsId` to be present with a string-literal value.
+
+use gts::GtsInstanceId;
+use gts_macros::{gts_instance, struct_to_gts_schema};
+
+#[struct_to_gts_schema(
+    dir_path = "schemas",
+    base = true,
+    schema_id = "gts.acme.core.test.perm.v1~",
+    description = "Test permission type for compile_fail/instance_missing_id",
+    properties = "id,action"
+)]
+#[derive(Debug)]
+pub struct PermV1 {
+    pub id: GtsInstanceId,
+    pub action: String,
+}
+
+fn main() {
+    let _ = gts_instance!(PermV1 {
+        action: "read".to_owned(),
+    });
+}

--- a/gts-macros/tests/compile_fail/instance_missing_id.stderr
+++ b/gts-macros/tests/compile_fail/instance_missing_id.stderr
@@ -1,0 +1,5 @@
+error: missing GTS instance-id field; the struct literal must contain exactly one of: $id, id, gts_id, gtsId
+  --> tests/compile_fail/instance_missing_id.rs:22:27
+   |
+22 |     let _ = gts_instance!(PermV1 {
+   |                           ^^^^^^

--- a/gts-macros/tests/compile_fail/instance_raw_id_not_literal.rs
+++ b/gts-macros/tests/compile_fail/instance_raw_id_not_literal.rs
@@ -1,0 +1,13 @@
+//! Test: `gts_instance_raw!` rejects a top-level `"id"` whose value is
+//! not a string literal. The macro needs to validate the GTS id shape
+//! at compile time, so a runtime expression can't be used.
+
+use gts_macros::gts_instance_raw;
+
+fn main() {
+    let runtime_id = "gts.acme.core.events.topic.v1~vendor.app.x.v1".to_owned();
+    let _ = gts_instance_raw!({
+        "id": runtime_id,
+        "name": "audit",
+    });
+}

--- a/gts-macros/tests/compile_fail/instance_raw_id_not_literal.stderr
+++ b/gts-macros/tests/compile_fail/instance_raw_id_not_literal.stderr
@@ -1,0 +1,5 @@
+error: `"id"` must be a string literal containing the full GTS instance id (e.g. "gts.acme.core.events.topic.v1~vendor.app.x.v1")
+  --> tests/compile_fail/instance_raw_id_not_literal.rs:10:15
+   |
+10 |         "id": runtime_id,
+   |               ^^^^^^^^^^

--- a/gts-macros/tests/compile_fail/instance_raw_missing_id.rs
+++ b/gts-macros/tests/compile_fail/instance_raw_missing_id.rs
@@ -1,0 +1,12 @@
+//! Test: `gts_instance_raw!` rejects a body that has no top-level `"id"`
+//! key. The macro requires the validated id to be present in the JSON
+//! object literal.
+
+use gts_macros::gts_instance_raw;
+
+fn main() {
+    let _ = gts_instance_raw!({
+        "name": "audit",
+        "description": "missing id",
+    });
+}

--- a/gts-macros/tests/compile_fail/instance_raw_missing_id.stderr
+++ b/gts-macros/tests/compile_fail/instance_raw_missing_id.stderr
@@ -1,0 +1,11 @@
+error: missing top-level `"id"` key in gts_instance_raw! body; the JSON object must contain `"id": "<full GTS instance id>"`
+  --> tests/compile_fail/instance_raw_missing_id.rs:8:13
+   |
+ 8 |       let _ = gts_instance_raw!({
+   |  _____________^
+ 9 | |         "name": "audit",
+10 | |         "description": "missing id",
+11 | |     });
+   | |______^
+   |
+   = note: this error originates in the macro `gts_instance_raw` (in Nightly builds, run with -Z macro-backtrace for more info)

--- a/gts-macros/tests/compile_fail/instance_raw_no_tilde.rs
+++ b/gts-macros/tests/compile_fail/instance_raw_no_tilde.rs
@@ -1,0 +1,14 @@
+//! Test: `gts_instance_raw!` rejects an `id` without `~` (i.e. a
+//! single-segment id, which by spec denotes neither a schema nor an
+//! instance — instance ids must be chained: `<type>~<segment>`).
+
+use gts_macros::gts_instance_raw;
+
+fn main() {
+    // Single, format-valid GTS segment — passes the gts-id format
+    // validator but fails the `~`-rule check.
+    let _ = gts_instance_raw!({
+        "id": "gts.acme.core.events.topic.v1",
+        "name": "x",
+    });
+}

--- a/gts-macros/tests/compile_fail/instance_raw_no_tilde.stderr
+++ b/gts-macros/tests/compile_fail/instance_raw_no_tilde.stderr
@@ -1,0 +1,5 @@
+error: instance id literal must contain at least one `~` (chained form: gts.<type>~<instance>)
+  --> tests/compile_fail/instance_raw_no_tilde.rs:11:15
+   |
+11 |         "id": "gts.acme.core.events.topic.v1",
+   |               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/gts-macros/tests/compile_fail/instance_unknown_attribute.rs
+++ b/gts-macros/tests/compile_fail/instance_unknown_attribute.rs
@@ -1,0 +1,29 @@
+//! Test: typed `gts_instance!` rejects an attribute on the struct
+//! literal that isn't `#[gts_static(...)]`. The macro owns its modifier
+//! surface; arbitrary attributes shouldn't silently pass through.
+
+use gts::GtsInstanceId;
+use gts_macros::{gts_instance, struct_to_gts_schema};
+
+#[struct_to_gts_schema(
+    dir_path = "schemas",
+    base = true,
+    schema_id = "gts.acme.core.test.perm.v1~",
+    description = "Test permission type for compile_fail/instance_unknown_attribute",
+    properties = "id,action"
+)]
+#[derive(Debug)]
+pub struct PermV1 {
+    pub id: GtsInstanceId,
+    pub action: String,
+}
+
+fn main() {
+    let _ = gts_instance! {
+        #[gts_unknown(foo)]
+        PermV1 {
+            id: "gts.acme.core.test.perm.v1~vendor.app.test.x.v1",
+            action: "read".to_owned(),
+        }
+    };
+}

--- a/gts-macros/tests/compile_fail/instance_unknown_attribute.stderr
+++ b/gts-macros/tests/compile_fail/instance_unknown_attribute.stderr
@@ -1,0 +1,5 @@
+error: unknown attribute on gts_instance! struct literal; expected `#[gts_static(...)]`
+  --> tests/compile_fail/instance_unknown_attribute.rs:23:9
+   |
+23 |         #[gts_unknown(foo)]
+   |         ^^^^^^^^^^^^^^^^^^^

--- a/gts-macros/tests/compile_fail/nested_direct_serialize_cfg_attr.stderr
+++ b/gts-macros/tests/compile_fail/nested_direct_serialize_cfg_attr.stderr
@@ -32,7 +32,7 @@ error[E0119]: conflicting implementations of trait `GtsDeserialize<'_>` for type
              where T: _::_serde::Deserialize<'de>;
    = note: this error originates in the attribute macro `struct_to_gts_schema` (in Nightly builds, run with -Z macro-backtrace for more info)
 
-error[E0119]: conflicting implementations of trait `GtsNoDirectSerialize` for type `AuditEventV1`
+error[E0119]: conflicting implementations of trait `gts::GtsNoDirectSerialize` for type `AuditEventV1`
   --> tests/compile_fail/nested_direct_serialize_cfg_attr.rs:19:1
    |
 19 | / #[struct_to_gts_schema(
@@ -45,11 +45,11 @@ error[E0119]: conflicting implementations of trait `GtsNoDirectSerialize` for ty
    | |__^
    |
    = note: conflicting implementation in crate `gts`:
-           - impl<T> GtsNoDirectSerialize for T
+           - impl<T> gts::GtsNoDirectSerialize for T
              where T: _::_serde::Serialize;
    = note: this error originates in the attribute macro `struct_to_gts_schema` (in Nightly builds, run with -Z macro-backtrace for more info)
 
-error[E0119]: conflicting implementations of trait `GtsNoDirectDeserialize` for type `AuditEventV1`
+error[E0119]: conflicting implementations of trait `gts::GtsNoDirectDeserialize` for type `AuditEventV1`
   --> tests/compile_fail/nested_direct_serialize_cfg_attr.rs:19:1
    |
 19 | / #[struct_to_gts_schema(
@@ -62,6 +62,6 @@ error[E0119]: conflicting implementations of trait `GtsNoDirectDeserialize` for 
    | |__^
    |
    = note: conflicting implementation in crate `gts`:
-           - impl<T> GtsNoDirectDeserialize for T
+           - impl<T> gts::GtsNoDirectDeserialize for T
              where for<'de> T: _::_serde::Deserialize<'de>;
    = note: this error originates in the attribute macro `struct_to_gts_schema` (in Nightly builds, run with -Z macro-backtrace for more info)

--- a/gts-macros/tests/compile_fail/non_gts_generic.stderr
+++ b/gts-macros/tests/compile_fail/non_gts_generic.stderr
@@ -3,15 +3,3 @@ error: struct_to_gts_schema: Base structs must have either an ID field (one of: 
    |
 17 | pub struct BaseEventV1<P> {
    |            ^^^^^^^^^^^
-
-error[E0412]: cannot find type `BaseEventV1` in this scope
-  --> tests/compile_fail/non_gts_generic.rs:31:17
-   |
-31 |     let _event: BaseEventV1<MyStruct> = BaseEventV1 {
-   |                 ^^^^^^^^^^^ not found in this scope
-
-error[E0422]: cannot find struct, variant or union type `BaseEventV1` in this scope
-  --> tests/compile_fail/non_gts_generic.rs:31:41
-   |
-31 |     let _event: BaseEventV1<MyStruct> = BaseEventV1 {
-   |                                         ^^^^^^^^^^^ not found in this scope

--- a/gts-macros/tests/instance_macro_tests.rs
+++ b/gts-macros/tests/instance_macro_tests.rs
@@ -1,0 +1,382 @@
+//! Runtime tests for `gts_instance!` and `gts_instance_raw!`.
+//!
+//! Covers:
+//! - Expression form: id rewriting from a string literal field, the
+//!   compile-time prefix assert on the happy path (mismatch cases live
+//!   in `compile_fail/`).
+//! - `#[gts_static(NAME)]`: emits `pub static NAME: LazyLock<T>` over
+//!   the rewritten struct.
+//! - Auto-derivation of the const-assert target for chained generic
+//!   carriers — `BaseV1::<LeafV1> { ... }` targets `LeafV1`'s `SCHEMA_ID`.
+//! - Alternative id field names (`gts_id`, `gtsId`) — picked from the
+//!   struct literal automatically, no extra modifier needed.
+//! - Raw expression form: id auto-injection into JSON.
+//!
+//! All fixture types here are produced by `#[struct_to_gts_schema]` —
+//! `gts_instance!` only requires `T: GtsSchema`, but in practice every
+//! consumer goes through the macro so the schema and the instance share
+//! the same registration story. Tests follow the same convention.
+
+#![allow(clippy::unwrap_used, clippy::expect_used)]
+
+use gts::GtsInstanceId;
+use gts_macros::{gts_instance, gts_instance_raw, struct_to_gts_schema};
+
+// ---------- Local test types ----------
+//
+// Generic example types — neutral naming to keep the tests applicable to
+// any GTS consumer, not tied to a particular framework or domain.
+
+#[struct_to_gts_schema(
+    dir_path = "schemas",
+    base = true,
+    schema_id = "gts.acme.core.events.topic.v1~",
+    description = "Test topic type used to exercise gts_instance!",
+    properties = "id,name,retention"
+)]
+#[derive(Debug)]
+pub struct TopicV1 {
+    pub id: GtsInstanceId,
+    pub name: String,
+    pub retention: String,
+}
+
+// Two-level chain: `BaseV1<P>` is the level-1 base (carrying `id` +
+// `payload`), `LeafV1` is a level-2 derived schema. Used to cover the
+// auto-derivation of the const-assert target from the carrier's
+// turbofish.
+
+#[struct_to_gts_schema(
+    dir_path = "schemas",
+    base = true,
+    schema_id = "gts.acme.core.test.base.v1~",
+    description = "Generic base type for chained-instance turbofish tests",
+    properties = "id,payload"
+)]
+#[derive(Debug)]
+pub struct BaseV1<P> {
+    pub id: GtsInstanceId,
+    pub payload: P,
+}
+
+#[struct_to_gts_schema(
+    dir_path = "schemas",
+    base = BaseV1,
+    schema_id = "gts.acme.core.test.base.v1~acme.core.test.leaf.v1~",
+    description = "Derived leaf for chained-instance turbofish tests",
+    properties = "name"
+)]
+#[derive(Debug)]
+pub struct LeafV1 {
+    pub name: String,
+}
+
+// Three-level chain: `L1OuterV1<P>` (base) -> `L2MidV1<D>` (derives from
+// L1OuterV1) -> `L3LeafV1` (derives from L2MidV1). Used to verify that the
+// auto-derivation walks through nested generics and picks the *deepest*
+// non-generic type, not any intermediate one. With a wrong choice the
+// const-assert would either reject the literal (target's SCHEMA_ID is
+// not a prefix of the full-chain id) or accept under a stale prefix —
+// the only target whose SCHEMA_ID is exactly the full-chain prefix is
+// `L3LeafV1`.
+
+#[struct_to_gts_schema(
+    dir_path = "schemas",
+    base = true,
+    schema_id = "gts.acme.core.test.l1.v1~",
+    description = "Level-1 base for three-level chained-instance tests",
+    properties = "id,payload"
+)]
+#[derive(Debug)]
+pub struct L1OuterV1<P> {
+    pub id: GtsInstanceId,
+    pub payload: P,
+}
+
+#[struct_to_gts_schema(
+    dir_path = "schemas",
+    base = L1OuterV1,
+    schema_id = "gts.acme.core.test.l1.v1~acme.core.test.l2.v1~",
+    description = "Level-2 mid for three-level chained-instance tests",
+    properties = "data"
+)]
+#[derive(Debug)]
+pub struct L2MidV1<D> {
+    pub data: D,
+}
+
+#[struct_to_gts_schema(
+    dir_path = "schemas",
+    base = L2MidV1,
+    schema_id = "gts.acme.core.test.l1.v1~acme.core.test.l2.v1~acme.core.test.l3.v1~",
+    description = "Level-3 leaf for three-level chained-instance tests",
+    properties = "value"
+)]
+#[derive(Debug)]
+pub struct L3LeafV1 {
+    pub value: String,
+}
+
+// =====================================================================
+//                  gts_instance! — expression form
+// =====================================================================
+
+#[test]
+fn typed_form_constructs_value_with_rewritten_id() {
+    let t: TopicV1 = gts_instance!(TopicV1 {
+        id: "gts.acme.core.events.topic.v1~vendor.app.orders.created.v1",
+        name: "orders".to_owned(),
+        retention: "P30D".to_owned(),
+    });
+
+    assert_eq!(t.name, "orders");
+    assert_eq!(t.retention, "P30D");
+    assert_eq!(
+        t.id.as_ref(),
+        "gts.acme.core.events.topic.v1~vendor.app.orders.created.v1"
+    );
+}
+
+#[test]
+fn typed_form_serialises_with_id_field() {
+    let t: TopicV1 = gts_instance!(TopicV1 {
+        id: "gts.acme.core.events.topic.v1~vendor.app.events.audit.v1",
+        name: "audit".to_owned(),
+        retention: "P7D".to_owned(),
+    });
+
+    let v = serde_json::to_value(&t).unwrap();
+    assert_eq!(
+        v["id"].as_str().unwrap(),
+        "gts.acme.core.events.topic.v1~vendor.app.events.audit.v1"
+    );
+    assert_eq!(v["name"].as_str().unwrap(), "audit");
+}
+
+#[test]
+fn typed_form_chained_derives_target_from_turbofish() {
+    // `BaseV1::<LeafV1>` carries `LeafV1` as the deepest type arg, so the
+    // const-assert target is derived as `LeafV1` and the literal must
+    // match `<LeafV1 as GtsSchema>::SCHEMA_ID` (the full chain prefix).
+    let v: BaseV1<LeafV1> = gts_instance!(BaseV1::<LeafV1> {
+        id: "gts.acme.core.test.base.v1~acme.core.test.leaf.v1~vendor.app.things.example.v1",
+        payload: LeafV1 {
+            name: "ex".to_owned()
+        },
+    });
+
+    assert_eq!(
+        v.id.as_ref(),
+        "gts.acme.core.test.base.v1~acme.core.test.leaf.v1~vendor.app.things.example.v1"
+    );
+}
+
+#[test]
+fn typed_form_three_level_chain_picks_deepest_generic() {
+    // `L1OuterV1::<L2MidV1<L3LeafV1>>` — the macro must descend through the
+    // intermediate generic carrier `L2MidV1<L3LeafV1>` and land on `L3LeafV1`,
+    // whose `SCHEMA_ID` matches the full-chain prefix. Targeting `L1OuterV1`
+    // would reject (extra `~` in suffix); targeting `L2MidV1<L3LeafV1>` would
+    // also reject (its `SCHEMA_ID` is the L1~L2~ prefix, leaving the L3
+    // segment in the suffix and tripping the no-tilde-in-segment check).
+    let v: L1OuterV1<L2MidV1<L3LeafV1>> = gts_instance!(L1OuterV1::<L2MidV1<L3LeafV1>> {
+        id: "gts.acme.core.test.l1.v1~acme.core.test.l2.v1~acme.core.test.l3.v1~vendor.app.things.deep.v1",
+        payload: L2MidV1 {
+            data: L3LeafV1 {
+                value: "deep".to_owned()
+            }
+        },
+    });
+
+    assert_eq!(
+        v.id.as_ref(),
+        "gts.acme.core.test.l1.v1~acme.core.test.l2.v1~acme.core.test.l3.v1~vendor.app.things.deep.v1"
+    );
+    assert_eq!(v.payload.data.value, "deep");
+}
+
+#[test]
+fn typed_form_unit_param_keeps_carrier_as_target() {
+    // `BaseV1::<()>` denotes a base-level instance — the descent stops on
+    // `()` (no `SCHEMA_ID`) and the carrier is kept as the target.
+    let v: BaseV1<()> = gts_instance!(BaseV1::<()> {
+        id: "gts.acme.core.test.base.v1~vendor.app.things.bare.v1",
+        payload: (),
+    });
+
+    assert_eq!(
+        v.id.as_ref(),
+        "gts.acme.core.test.base.v1~vendor.app.things.bare.v1"
+    );
+}
+
+// =====================================================================
+//             gts_instance! — #[gts_static(NAME)] item form
+// =====================================================================
+
+gts_instance! {
+    #[gts_static(ORDERS_TOPIC)]
+    TopicV1 {
+        id: "gts.acme.core.events.topic.v1~vendor.app.orders.created.v1",
+        name: "orders".to_owned(),
+        retention: "P30D".to_owned(),
+    }
+}
+
+#[test]
+fn static_form_exposes_typed_static_value() {
+    let t: &TopicV1 = &ORDERS_TOPIC;
+    assert_eq!(t.name, "orders");
+    assert_eq!(t.retention, "P30D");
+    assert_eq!(
+        t.id.as_ref(),
+        "gts.acme.core.events.topic.v1~vendor.app.orders.created.v1"
+    );
+}
+
+#[test]
+fn static_form_static_is_lazy_and_stable() {
+    let first = &*ORDERS_TOPIC;
+    let second = &*ORDERS_TOPIC;
+    assert!(std::ptr::eq(first, second));
+}
+
+// `#[gts_static(NAME)]` over a chained generic carrier — auto-derivation
+// resolves the const-assert target to `LeafV1`.
+
+gts_instance! {
+    #[gts_static(EXAMPLE_LEAF)]
+    BaseV1::<LeafV1> {
+        id: "gts.acme.core.test.base.v1~acme.core.test.leaf.v1~vendor.app.things.example.v1",
+        payload: LeafV1 { name: "ex".to_owned() },
+    }
+}
+
+#[test]
+fn static_form_chained_carrier_with_auto_derivation() {
+    let v: &BaseV1<LeafV1> = &EXAMPLE_LEAF;
+    assert_eq!(
+        v.id.as_ref(),
+        "gts.acme.core.test.base.v1~acme.core.test.leaf.v1~vendor.app.things.example.v1"
+    );
+    assert_eq!(v.payload.name, "ex");
+}
+
+// =====================================================================
+//                       gts_instance_raw! (JSON)
+// =====================================================================
+
+#[test]
+fn raw_form_constructs_json_value_with_validated_id() {
+    let v: serde_json::Value = gts_instance_raw!({
+        "id": "gts.acme.core.events.topic.v1~vendor.app.events.audit.v1",
+        "name": "audit",
+        "description": "Audit log events"
+    });
+
+    assert_eq!(
+        v["id"].as_str().unwrap(),
+        "gts.acme.core.events.topic.v1~vendor.app.events.audit.v1"
+    );
+    assert_eq!(v["name"].as_str().unwrap(), "audit");
+    assert_eq!(v["description"].as_str().unwrap(), "Audit log events");
+}
+
+#[test]
+fn raw_form_supports_chained_instance_ids() {
+    let v: serde_json::Value = gts_instance_raw!({
+        "id": "gts.acme.core.test.base.v1~acme.core.test.leaf.v1~vendor.app.things.x.v1",
+        "value": 42,
+    });
+
+    assert_eq!(
+        v["id"].as_str().unwrap(),
+        "gts.acme.core.test.base.v1~acme.core.test.leaf.v1~vendor.app.things.x.v1"
+    );
+    assert_eq!(v["value"].as_i64().unwrap(), 42);
+}
+
+#[test]
+fn raw_form_supports_nested_objects_and_arrays() {
+    // Top-level `id` is the only key the macro inspects; nested objects
+    // and arrays pass through to `json!` untouched.
+    let v: serde_json::Value = gts_instance_raw!({
+        "id": "gts.acme.core.events.topic.v1~vendor.app.events.audit.v1",
+        "tags": ["a", "b", "c"],
+        "meta": { "id": "nested-not-touched", "count": 3 },
+    });
+
+    assert_eq!(
+        v["id"].as_str().unwrap(),
+        "gts.acme.core.events.topic.v1~vendor.app.events.audit.v1"
+    );
+    assert_eq!(v["tags"][1].as_str().unwrap(), "b");
+    assert_eq!(v["meta"]["id"].as_str().unwrap(), "nested-not-touched");
+    assert_eq!(v["meta"]["count"].as_i64().unwrap(), 3);
+}
+
+// =====================================================================
+//          gts_instance! — alternative id field names (gts_id / gtsId)
+// =====================================================================
+
+#[struct_to_gts_schema(
+    dir_path = "schemas",
+    base = true,
+    schema_id = "gts.acme.core.events.legacy_topic.v1~",
+    description = "Legacy-style base struct using gts_id instead of id",
+    properties = "gts_id,name"
+)]
+#[derive(Debug)]
+pub struct LegacyTopicV1 {
+    pub gts_id: GtsInstanceId,
+    pub name: String,
+}
+
+#[test]
+fn typed_form_picks_up_gts_id_field_automatically() {
+    // Schema struct uses `gts_id` instead of `id` — the macro picks
+    // whichever reserved id-field name appears in the literal.
+    let t: LegacyTopicV1 = gts_instance!(LegacyTopicV1 {
+        gts_id: "gts.acme.core.events.legacy_topic.v1~vendor.app.legacy.example.v1",
+        name: "legacy".to_owned(),
+    });
+
+    assert_eq!(t.name, "legacy");
+    assert_eq!(
+        t.gts_id.as_ref(),
+        "gts.acme.core.events.legacy_topic.v1~vendor.app.legacy.example.v1"
+    );
+}
+
+// Same coverage for the camelCase alias `gtsId` — the third reserved name
+// accepted by `struct_to_gts_schema`.
+
+#[struct_to_gts_schema(
+    dir_path = "schemas",
+    base = true,
+    schema_id = "gts.acme.core.events.legacy_topic_camel.v1~",
+    description = "Legacy-style base struct using the gtsId camelCase alias",
+    properties = "gtsId,name"
+)]
+#[derive(Debug)]
+#[allow(non_snake_case)]
+pub struct LegacyTopicCamelV1 {
+    pub gtsId: GtsInstanceId,
+    pub name: String,
+}
+
+#[test]
+fn typed_form_picks_up_gtsid_camel_case_field_automatically() {
+    // gtsId is the camelCase alias accepted alongside id / gts_id; the
+    // macro should pick it up identically without any extra modifier.
+    let t: LegacyTopicCamelV1 = gts_instance!(LegacyTopicCamelV1 {
+        gtsId: "gts.acme.core.events.legacy_topic_camel.v1~vendor.app.legacy.example.v1",
+        name: "legacy".to_owned(),
+    });
+
+    assert_eq!(t.name, "legacy");
+    assert_eq!(
+        t.gtsId.as_ref(),
+        "gts.acme.core.events.legacy_topic_camel.v1~vendor.app.legacy.example.v1"
+    );
+}

--- a/gts/src/ops.rs
+++ b/gts/src/ops.rs
@@ -223,7 +223,7 @@ impl GtsOps {
             .and_then(|v| v.as_array())
             .map(|arr| {
                 arr.iter()
-                    .filter_map(|v| v.as_str().map(ToString::to_string))
+                    .filter_map(|v| v.as_str().map(str::to_owned))
                     .collect()
             })
             .unwrap_or(default_cfg.entity_id_fields);
@@ -233,7 +233,7 @@ impl GtsOps {
             .and_then(|v| v.as_array())
             .map(|arr| {
                 arr.iter()
-                    .filter_map(|v| v.as_str().map(ToString::to_string))
+                    .filter_map(|v| v.as_str().map(str::to_owned))
                     .collect()
             })
             .unwrap_or(default_cfg.schema_id_fields);

--- a/gts/src/path_resolver.rs
+++ b/gts/src/path_resolver.rs
@@ -35,7 +35,7 @@ impl JsonPathResolver {
     fn split_raw_parts(norm: &str) -> Vec<String> {
         norm.split('.')
             .filter(|s| !s.is_empty())
-            .map(ToString::to_string)
+            .map(str::to_owned)
             .collect()
     }
 

--- a/gts/src/schema_cast.rs
+++ b/gts/src/schema_cast.rs
@@ -205,7 +205,7 @@ impl GtsEntityCastResult {
             .and_then(|r| r.as_array())
             .map(|arr| {
                 arr.iter()
-                    .filter_map(|v| v.as_str().map(ToString::to_string))
+                    .filter_map(|v| v.as_str().map(str::to_owned))
                     .collect()
             })
             .unwrap_or_default();
@@ -561,7 +561,7 @@ impl GtsEntityCastResult {
             .and_then(|r| r.as_array())
             .map(|arr| {
                 arr.iter()
-                    .filter_map(|v| v.as_str().map(ToString::to_string))
+                    .filter_map(|v| v.as_str().map(str::to_owned))
                     .collect()
             })
             .unwrap_or_default();
@@ -571,7 +571,7 @@ impl GtsEntityCastResult {
             .and_then(|r| r.as_array())
             .map(|arr| {
                 arr.iter()
-                    .filter_map(|v| v.as_str().map(ToString::to_string))
+                    .filter_map(|v| v.as_str().map(str::to_owned))
                     .collect()
             })
             .unwrap_or_default();
@@ -619,11 +619,11 @@ impl GtsEntityCastResult {
                 if let (Some(old_e), Some(new_e)) = (old_enum, new_enum) {
                     let old_enum_set: HashSet<String> = old_e
                         .iter()
-                        .filter_map(|v| v.as_str().map(ToString::to_string))
+                        .filter_map(|v| v.as_str().map(str::to_owned))
                         .collect();
                     let new_enum_set: HashSet<String> = new_e
                         .iter()
-                        .filter_map(|v| v.as_str().map(ToString::to_string))
+                        .filter_map(|v| v.as_str().map(str::to_owned))
                         .collect();
 
                     if check_backward {

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,0 +1,3 @@
+[toolchain]
+channel = "1.95.0"
+components = ["rustfmt", "clippy"]


### PR DESCRIPTION
Construction macros for typed and raw-JSON GTS instances. Take a Rust
struct literal (or JSON object literal) where the GTS instance id lives
in the dedicated id field/key as a string literal, validate it at
proc-macro time against the full GTS spec format, split it into
prefix + segment, rewrite the field's value to GtsInstanceId::new(...),
and const-assert that the literal's prefix matches
<T as GtsSchema>::SCHEMA_ID.

The shape mirrors plain Rust / JSON literals so consumers (and LLMs)
can pattern-match the syntax directly without learning a DSL.

- gts_instance!(T { id: "gts...", ...other fields... }) for typed
  values. The id field is picked by name from the literal — id, gts_id,
  or gtsId — matching the three names accepted by
  struct_to_gts_schema, so no extra modifier is needed for legacy-style
  schemas.
- For chained generic carriers, the const-assert target is auto-derived
  from the struct literal's turbofish: the macro descends through
  angle-bracketed type args, picking the deepest non-generic path as
  the conforming schema. So BaseV1::<LeafV1> { ... } targets LeafV1's
  full-chain SCHEMA_ID; BaseV1::<MiddleV1<LeafV1>> likewise reaches
  LeafV1; BaseV1::<()> { ... } keeps the carrier as a base-level
  instance. Bare BaseV1 { ... } (no turbofish on a generic carrier) is
  rejected — the turbofish is the macro's only signal for picking the
  conforming type.
- #[gts_static(NAME)] outer attribute wraps the produced value in a
  pub static NAME: LazyLock<T> binding (item form).
- gts_instance_raw!({ "id": "gts...", "other": "fields" }) for instances
  without a Rust struct counterpart. The macro walks top-level entries
  to extract "id"; nested objects/arrays pass through to
  serde_json::json! unchanged. At runtime the macro unconditionally
  re-inserts the validated id so any payload edit can't override the
  source-of-truth literal.
- Span-anchored proc-macro errors for: missing id field/key, non-literal
  id, ambiguous id (duplicate reserved field names), unknown attribute,
  malformed id literal, struct-update syntax. Thirteen runtime tests +
  five descent unit tests + twelve compile_fail cases lock the surface
  in.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added gts_instance! and gts_instance_raw! macros with compile-time validation for instance IDs and support for #[gts_static(NAME)].

* **Tests**
  * Added extensive compile-fail and runtime tests covering invalid IDs, missing/ non-literal IDs, wildcard/tildes rules, chained schemas, and attribute validation.

* **Chores**
  * Bumped Rust toolchain to 1.95.0 and switched CI to use rust-toolchain.toml for toolchain setup.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->