### PR TITLE
chore: bump version 0.9.3 -> 0.9.4

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -527,7 +527,7 @@ checksum = "0cc23270f6e1808e30a928bdc84dea0b9b4136a8bc82338574f23baf47bbd280"
 
 [[package]]
 name = "gts"
-version = "0.9.3"
+version = "0.9.4"
 dependencies = [
  "gts-id",
  "jsonschema",
@@ -545,7 +545,7 @@ dependencies = [
 
 [[package]]
 name = "gts-cli"
-version = "0.9.3"
+version = "0.9.4"
 dependencies = [
  "anyhow",
  "axum",
@@ -565,14 +565,14 @@ dependencies = [
 
 [[package]]
 name = "gts-id"
-version = "0.9.3"
+version = "0.9.4"
 dependencies = [
  "thiserror",
 ]
 
 [[package]]
 name = "gts-macros"
-version = "0.9.3"
+version = "0.9.4"
 dependencies = [
  "gts",
  "gts-id",
@@ -589,7 +589,7 @@ dependencies = [
 
 [[package]]
 name = "gts-macros-cli"
-version = "0.9.3"
+version = "0.9.4"
 dependencies = [
  "anyhow",
  "clap",
@@ -604,7 +604,7 @@ dependencies = [
 
 [[package]]
 name = "gts-validator"
-version = "0.9.3"
+version = "0.9.4"
 dependencies = [
  "anyhow",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -147,12 +147,12 @@ verbose_file_reads = "deny"
 module_name_repetitions = "allow"
 
 [workspace.dependencies]
-gts = { version = "0.9.3", path = "gts" }
-gts-cli = { version = "0.9.3", path = "gts-cli" }
-gts-id = { version = "0.9.3", path = "gts-id" }
-gts-macros = { version = "0.9.3", path = "gts-macros" }
-gts-macros-cli = { version = "0.9.3", path = "gts-macros-cli" }
-gts-validator = { version = "0.9.3", path = "gts-validator" }
+gts = { version = "0.9.4", path = "gts" }
+gts-cli = { version = "0.9.4", path = "gts-cli" }
+gts-id = { version = "0.9.4", path = "gts-id" }
+gts-macros = { version = "0.9.4", path = "gts-macros" }
+gts-macros-cli = { version = "0.9.4", path = "gts-macros-cli" }
+gts-validator = { version = "0.9.4", path = "gts-validator" }
 
 # Core dependencies
 serde = { version = "1.0", features = ["derive"] }

--- a/gts-cli/Cargo.toml
+++ b/gts-cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "gts-cli"
-version = "0.9.3"
+version = "0.9.4"
 edition.workspace = true
 authors.workspace = true
 license.workspace = true

--- a/gts-id/Cargo.toml
+++ b/gts-id/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "gts-id"
-version = "0.9.3"
+version = "0.9.4"
 edition.workspace = true
 authors.workspace = true
 license.workspace = true

--- a/gts-macros-cli/Cargo.toml
+++ b/gts-macros-cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "gts-macros-cli"
-version = "0.9.3"
+version = "0.9.4"
 edition.workspace = true
 authors.workspace = true
 license.workspace = true

--- a/gts-macros/Cargo.toml
+++ b/gts-macros/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "gts-macros"
-version = "0.9.3"
+version = "0.9.4"
 edition.workspace = true
 authors.workspace = true
 license.workspace = true

--- a/gts-validator/Cargo.toml
+++ b/gts-validator/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "gts-validator"
-version = "0.9.3"
+version = "0.9.4"
 edition.workspace = true
 authors.workspace = true
 license.workspace = true

--- a/gts/Cargo.toml
+++ b/gts/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "gts"
-version = "0.9.3"
+version = "0.9.4"
 edition.workspace = true
 authors.workspace = true
 license.workspace = true


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Bumped workspace package versions from 0.9.3 to 0.9.4 across all internal crates.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/GlobalTypeSystem/gts-rust/pull/84)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->