### PR TITLE
fix(gts-macros): correct schema emission for derived and generic types

### DIFF
--- a/gts-macros-cli/README.md
+++ b/gts-macros-cli/README.md
@@ -1,0 +1,33 @@
+# gts-macros-cli
+
+Demo CLI for `gts-macros`: renders the in-repo inheritance chain
+(`BaseEventV1 → AuditPayloadV1 → PlaceOrderDataV1 → PlaceOrderDataPayloadV1`)
+as JSON Schemas, prints a sample serialised event, and optionally dumps
+everything to disk for inspection and downstream validation.
+
+## Usage
+
+Print the demo output (schemas, sample event, `gts_schema_for!` cases)
+to stdout:
+
+```bash
+cargo run -p gts-macros-cli
+```
+
+Dump artifacts to a directory:
+
+```bash
+cargo run -p gts-macros-cli -- --dump <DIR>
+```
+
+The dump produces:
+
+| File | Tracked? | Purpose |
+|---|---|---|
+| `<schema_id>.schema.json` × 4 | yes | One JSON Schema per chain level, committed under `src/schemas/` as fixtures and as the document that downstream tools (e.g. `validate.sh`) consume. |
+| `<uuid>.json` | no | Sample event built by `create_sample_event()` with hard-coded UUIDs; serves as the `-d <instance>` input for `validate.sh`. |
+| `validate.sh` | no | Generated `ajv-cli validate` invocation against the sample event. Requires `node` and `ajv-cli` + `ajv-formats` available via `npx`. |
+
+Anything other than `*.schema.json` inside `src/schemas/` is gated by a
+directory-local `.gitignore`; running `--dump` repeatedly never adds
+clutter to `git status`.

--- a/gts-macros-cli/src/main.rs
+++ b/gts-macros-cli/src/main.rs
@@ -154,33 +154,33 @@ fn dump_to_directory(dir: &Path) -> anyhow::Result<()> {
     std::fs::write(&instance_path, instance_json)?;
     println!("Saved instance: {}", instance_path.display());
 
-    // Save schemas using gts_schema_for! macro
-    // Schema 1: BaseEventV1 (base type)
+    // Save schemas using `gts_schema_for!` macro.
+    //
+    // Each `gts_schema_for!(T)` call returns T's *own* JSON Schema — the
+    // base emits a root schema with its properties; each derived level
+    // emits an `allOf`-overlay schema that $refs back to its parent.
+    //
+    // NOTE: per commit 77bdf46 ("type-parameter independent base schemas"),
+    // wrapping a generic carrier — e.g. `gts_schema_for!(BaseEventV1<chain>)` —
+    // does NOT produce the chain's leaf schema: it returns BaseEventV1's
+    // own schema regardless of the type parameter. Always call
+    // `gts_schema_for!` on the type whose schema you actually want;
+    // otherwise every file ends up with `$id = gts://...type.v1~` and
+    // imitates the base, breaking the file-name <-> document-id invariant.
     let schema1 = gts_schema_for!(test_structs::BaseEventV1<()>);
     save_schema(dir, &schema1, test_structs::BaseEventV1::<()>::SCHEMA_ID)?;
 
-    // Schema 2: BaseEventV1<AuditPayloadV1>
-    let schema2 = gts_schema_for!(test_structs::BaseEventV1<test_structs::AuditPayloadV1<()>>);
+    let schema2 = gts_schema_for!(test_structs::AuditPayloadV1<()>);
     save_schema(dir, &schema2, test_structs::AuditPayloadV1::<()>::SCHEMA_ID)?;
 
-    // Schema 3: BaseEventV1<AuditPayloadV1<PlaceOrderDataV1>>
-    let schema3 = gts_schema_for!(
-        test_structs::BaseEventV1<test_structs::AuditPayloadV1<test_structs::PlaceOrderDataV1<()>>>
-    );
+    let schema3 = gts_schema_for!(test_structs::PlaceOrderDataV1<()>);
     save_schema(
         dir,
         &schema3,
         test_structs::PlaceOrderDataV1::<()>::SCHEMA_ID,
     )?;
 
-    // Schema 4: BaseEventV1<AuditPayloadV1<PlaceOrderDataV1<PlaceOrderDataPayloadV1>>>
-    let schema4 = gts_schema_for!(
-        test_structs::BaseEventV1<
-            test_structs::AuditPayloadV1<
-                test_structs::PlaceOrderDataV1<test_structs::PlaceOrderDataPayloadV1>,
-            >,
-        >
-    );
+    let schema4 = gts_schema_for!(test_structs::PlaceOrderDataPayloadV1);
     save_schema(
         dir,
         &schema4,

--- a/gts-macros-cli/src/schemas/.gitignore
+++ b/gts-macros-cli/src/schemas/.gitignore
@@ -1,0 +1,6 @@
+# Track committed JSON Schema fixtures only; everything else in this
+# directory (sample-event JSON, `validate.sh`, future helpers) is a
+# regenerated artifact of `cargo run -p gts-macros-cli -- --dump`.
+*
+!.gitignore
+!*.schema.json

--- a/gts-macros-cli/src/schemas/gts.x.core.events.type.v1~.schema.json
+++ b/gts-macros-cli/src/schemas/gts.x.core.events.type.v1~.schema.json
@@ -4,13 +4,6 @@
   "additionalProperties": false,
   "description": "Base event type definition",
   "properties": {
-    "event_type": {
-      "description": "GTS schema identifier",
-      "format": "gts-schema-id",
-      "title": "GTS Schema ID",
-      "type": "string",
-      "x-gts-ref": "gts.*"
-    },
     "id": {
       "format": "uuid",
       "type": "string"
@@ -19,20 +12,28 @@
       "type": "object"
     },
     "sequence_id": {
+      "format": "uint64",
+      "minimum": 0,
       "type": "integer"
     },
     "tenant_id": {
       "format": "uuid",
       "type": "string"
+    },
+    "type": {
+      "description": "GTS schema identifier",
+      "format": "gts-schema-id",
+      "title": "GTS Schema ID",
+      "type": "string",
+      "x-gts-ref": "gts.*"
     }
   },
   "required": [
-    "event_type",
+    "type",
     "id",
-    "payload",
+    "tenant_id",
     "sequence_id",
-    "tenant_id"
+    "payload"
   ],
-  "title": "BaseEventV1",
   "type": "object"
 }

--- a/gts-macros-cli/src/schemas/gts.x.core.events.type.v1~x.core.audit.event.v1~.schema.json
+++ b/gts-macros-cli/src/schemas/gts.x.core.events.type.v1~x.core.audit.event.v1~.schema.json
@@ -1,35 +1,42 @@
 {
   "$id": "gts://gts.x.core.events.type.v1~x.core.audit.event.v1~",
   "$schema": "http://json-schema.org/draft-07/schema#",
+  "additionalProperties": false,
   "allOf": [
     {
       "$ref": "gts://gts.x.core.events.type.v1~"
     },
     {
       "properties": {
-        "data": {
+        "payload": {
+          "additionalProperties": false,
+          "properties": {
+            "data": {
+              "type": "object"
+            },
+            "ip_address": {
+              "type": "string"
+            },
+            "user_agent": {
+              "type": "string"
+            },
+            "user_id": {
+              "format": "uuid",
+              "type": "string"
+            }
+          },
+          "required": [
+            "user_agent",
+            "user_id",
+            "ip_address",
+            "data"
+          ],
           "type": "object"
-        },
-        "ip_address": {
-          "type": "string"
-        },
-        "user_agent": {
-          "type": "string"
-        },
-        "user_id": {
-          "format": "uuid",
-          "type": "string"
         }
       },
-      "required": [
-        "data",
-        "ip_address",
-        "user_agent",
-        "user_id"
-      ]
+      "type": "object"
     }
   ],
   "description": "Audit event with user context",
-  "title": "AuditPayloadV1 (extends BaseEventV1)",
   "type": "object"
 }

--- a/gts-macros-cli/src/schemas/gts.x.core.events.type.v1~x.core.audit.event.v1~x.marketplace.orders.purchase.v1~.schema.json
+++ b/gts-macros-cli/src/schemas/gts.x.core.events.type.v1~x.core.audit.event.v1~x.marketplace.orders.purchase.v1~.schema.json
@@ -1,28 +1,44 @@
 {
   "$id": "gts://gts.x.core.events.type.v1~x.core.audit.event.v1~x.marketplace.orders.purchase.v1~",
   "$schema": "http://json-schema.org/draft-07/schema#",
+  "additionalProperties": false,
   "allOf": [
     {
       "$ref": "gts://gts.x.core.events.type.v1~x.core.audit.event.v1~"
     },
     {
       "properties": {
-        "order_id": {
-          "format": "uuid",
-          "type": "string"
-        },
-        "product_id": {
-          "format": "uuid",
-          "type": "string"
+        "payload": {
+          "properties": {
+            "data": {
+              "additionalProperties": false,
+              "properties": {
+                "last": {
+                  "type": "object"
+                },
+                "order_id": {
+                  "format": "uuid",
+                  "type": "string"
+                },
+                "product_id": {
+                  "format": "uuid",
+                  "type": "string"
+                }
+              },
+              "required": [
+                "order_id",
+                "product_id",
+                "last"
+              ],
+              "type": "object"
+            }
+          },
+          "type": "object"
         }
       },
-      "required": [
-        "order_id",
-        "product_id"
-      ]
+      "type": "object"
     }
   ],
   "description": "Order placement audit event",
-  "title": "PlaceOrderDataV1 (extends AuditPayloadV1)",
   "type": "object"
 }

--- a/gts-macros-cli/src/schemas/gts.x.core.events.type.v1~x.core.audit.event.v1~x.marketplace.orders.purchase.v1~x.marketplace.order_purchase.payload.v1~.schema.json
+++ b/gts-macros-cli/src/schemas/gts.x.core.events.type.v1~x.core.audit.event.v1~x.marketplace.orders.purchase.v1~x.marketplace.order_purchase.payload.v1~.schema.json
@@ -1,23 +1,40 @@
 {
   "$id": "gts://gts.x.core.events.type.v1~x.core.audit.event.v1~x.marketplace.orders.purchase.v1~x.marketplace.order_purchase.payload.v1~",
   "$schema": "http://json-schema.org/draft-07/schema#",
+  "additionalProperties": false,
   "allOf": [
     {
       "$ref": "gts://gts.x.core.events.type.v1~x.core.audit.event.v1~x.marketplace.orders.purchase.v1~"
     },
     {
       "properties": {
-        "order_id": {
-          "format": "uuid",
-          "type": "string"
+        "payload": {
+          "properties": {
+            "data": {
+              "properties": {
+                "last": {
+                  "additionalProperties": false,
+                  "properties": {
+                    "order_id": {
+                      "format": "uuid",
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "order_id"
+                  ],
+                  "type": "object"
+                }
+              },
+              "type": "object"
+            }
+          },
+          "type": "object"
         }
       },
-      "required": [
-        "order_id"
-      ]
+      "type": "object"
     }
   ],
   "description": "Order placement audit event",
-  "title": "PlaceOrderDataPayloadV1 (extends PlaceOrderDataV1)",
   "type": "object"
 }

--- a/gts-macros/src/lib.rs
+++ b/gts-macros/src/lib.rs
@@ -1199,6 +1199,24 @@ pub fn struct_to_gts_schema(attr: TokenStream, item: TokenStream) -> TokenStream
                     }
                 }
 
+                // Resolve internal $ref references to GtsInstanceId and GtsSchemaId.
+                // schemars emits them as `#/$defs/...` pointers into the per-type
+                // generator scope; once we drop the schemars wrapper they become
+                // dangling. Inline the canonical schema fragment instead so the
+                // generated document is self-contained (same fix as the
+                // non-generic branch below).
+                if let Some(props_obj) = properties.as_object_mut() {
+                    for (_key, value) in props_obj.iter_mut() {
+                        if let Some(ref_str) = value.get("$ref").and_then(|v| v.as_str()) {
+                            if ref_str == "#/$defs/GtsInstanceId" {
+                                *value = gts::GtsInstanceId::json_schema_value();
+                            } else if ref_str == "#/$defs/GtsSchemaId" {
+                                *value = gts::GtsSchemaId::json_schema_value();
+                            }
+                        }
+                    }
+                }
+
                 // If no parent (base type), return simple schema without allOf
                 // Base types have additionalProperties: false at root level
                 // Generic fields are just {"type": "object"} (will be extended by children)

--- a/gts-macros/src/lib.rs
+++ b/gts-macros/src/lib.rs
@@ -1102,12 +1102,33 @@ pub fn struct_to_gts_schema(attr: TokenStream, item: TokenStream) -> TokenStream
         "::gts::GtsSerialize + ::gts::GtsSchema",
     );
 
+    // Emit `outer_generic_path()` for derived types so the overlay can be
+    // wrapped at the right depth (full path from the document root, not just
+    // one parent level). Base types use the default empty path.
+    let outer_generic_path_method = match &args.base {
+        BaseAttr::Parent(parent_ident) => quote! {
+            fn outer_generic_path() -> Vec<&'static str> {
+                let mut path =
+                    <#parent_ident<()> as ::gts::GtsSchema>::outer_generic_path();
+                if let Some(field) =
+                    <#parent_ident<()> as ::gts::GtsSchema>::GENERIC_FIELD
+                {
+                    path.push(field);
+                }
+                path
+            }
+        },
+        BaseAttr::IsBase => quote! {},
+    };
+
     let gts_schema_impl = if has_generic {
         let generic_param = input.generics.type_params().next().unwrap();
         let generic_ident = &generic_param.ident;
         let generic_field_for_path = generic_field_name.as_deref().unwrap_or_default();
 
         quote! {
+            #outer_generic_path_method
+
             fn gts_schema() -> serde_json::Value {
                 Self::gts_schema_with_refs()
             }
@@ -1224,6 +1245,7 @@ pub fn struct_to_gts_schema(attr: TokenStream, item: TokenStream) -> TokenStream
                     let mut schema = serde_json::json!({
                         "$id": format!("gts://{}", schema_id),
                         "$schema": "http://json-schema.org/draft-07/schema#",
+                        "description": #description,
                         "type": "object",
                         "additionalProperties": false,
                         "properties": properties
@@ -1234,24 +1256,31 @@ pub fn struct_to_gts_schema(attr: TokenStream, item: TokenStream) -> TokenStream
                     return schema;
                 }
 
-                // Build the nesting path from outer to inner generic fields
-                // For Outer<Middle<Inner>> where Outer has field "a" and Middle has field "b":
-                //   - innermost is Inner
-                //   - parent is derived from innermost's schema ID
-                //   - path ["a", "b"] wraps Inner's properties
-                let nesting_path = Self::collect_nesting_path();
-
-                // Get the generic field name for the innermost type (if it has one)
-                // This field should NOT have additionalProperties: false since it will be extended
-                let innermost_generic_field = <#generic_ident as ::gts::GtsSchema>::GENERIC_FIELD;
-
-                // Wrap properties in the nesting path
-                let nested_properties = Self::wrap_in_nesting_path(&nesting_path, properties, required.clone(), innermost_generic_field);
+                // Wrap our overlay properties at the FULL nesting path from
+                // the document root. For a chain `A -> B -> C -> D` this puts
+                // D's fields under
+                // `properties.A_genfield.properties.B_genfield.properties.C_genfield`,
+                // exactly where they sit in a composed instance. Wrapping
+                // only at the immediate parent's generic field would land
+                // deeply-nested fields at the wrong schema level and silently
+                // violate parent chains' `additionalProperties: false`
+                // invariants (gts-spec sec 3.1).
+                let owned_path = Self::outer_generic_path();
+                let path_refs: Vec<&str> = owned_path.iter().copied().collect();
+                let innermost_generic_field =
+                    <#generic_ident as ::gts::GtsSchema>::GENERIC_FIELD;
+                let nested_properties = Self::wrap_in_nesting_path(
+                    &path_refs,
+                    properties,
+                    required.clone(),
+                    innermost_generic_field,
+                );
 
                 // Child type - use allOf with $ref to parent
                 serde_json::json!({
                     "$id": format!("gts://{}", schema_id),
                     "$schema": "http://json-schema.org/draft-07/schema#",
+                    "description": #description,
                     "type": "object",
                     "additionalProperties": false,
                     "allOf": [
@@ -1265,23 +1294,9 @@ pub fn struct_to_gts_schema(attr: TokenStream, item: TokenStream) -> TokenStream
             }
         }
     } else {
-        // For non-generic child types extending a generic base, we need to get the parent's
-        // generic field name at compile time to properly nest the child properties
-        let parent_generic_field_code = match &args.base {
-            BaseAttr::Parent(parent_ident) => {
-                quote! {
-                    // Get the parent's generic field name for nesting
-                    let parent_generic_field: Option<&'static str> = <#parent_ident<()> as ::gts::GtsSchema>::GENERIC_FIELD;
-                }
-            }
-            BaseAttr::IsBase => {
-                quote! {
-                    let parent_generic_field: Option<&'static str> = None;
-                }
-            }
-        };
-
         quote! {
+            #outer_generic_path_method
+
             fn gts_schema() -> serde_json::Value {
                 Self::gts_schema_with_refs()
             }
@@ -1335,6 +1350,7 @@ pub fn struct_to_gts_schema(attr: TokenStream, item: TokenStream) -> TokenStream
                     let mut schema = serde_json::json!({
                         "$id": format!("gts://{}", schema_id),
                         "$schema": "http://json-schema.org/draft-07/schema#",
+                        "description": #description,
                         "type": "object",
                         "additionalProperties": false,
                         "properties": properties
@@ -1345,19 +1361,18 @@ pub fn struct_to_gts_schema(attr: TokenStream, item: TokenStream) -> TokenStream
                     return schema;
                 }
 
-                // Get the parent's generic field name for nesting child properties
-                #parent_generic_field_code
-
-                // Child type - use allOf with $ref to parent
-                // Parent MUST have a generic field - this is enforced by compile-time assertion
-                let field_name = parent_generic_field
-                    .expect("Parent struct must have a generic field for derived types to extend");
-
-                // Wrap properties in the parent's generic field path
-                let nested_properties = Self::wrap_in_nesting_path(&[field_name], properties, required, None);
+                // Wrap properties in the FULL nesting path from the
+                // document root (not just the immediate parent's generic
+                // field). For chains deeper than 2 levels this puts the
+                // fields at the correct schema depth and keeps every parent
+                // chain's `additionalProperties: false` honoured.
+                let owned_path = Self::outer_generic_path();
+                let path_refs: Vec<&str> = owned_path.iter().copied().collect();
+                let nested_properties = Self::wrap_in_nesting_path(&path_refs, properties, required, None);
                 serde_json::json!({
                     "$id": format!("gts://{}", schema_id),
                     "$schema": "http://json-schema.org/draft-07/schema#",
+                    "description": #description,
                     "type": "object",
                     "additionalProperties": false,
                     "allOf": [

--- a/gts-macros/tests/inheritance_tests.rs
+++ b/gts-macros/tests/inheritance_tests.rs
@@ -337,6 +337,64 @@ mod tests {
     }
 
     #[test]
+    fn test_generic_base_schema_has_no_dangling_defs_refs() {
+        // Regression for the generic-base branch of `gts_schema_with_refs_allof`:
+        // schemars emits `GtsSchemaId` / `GtsInstanceId` fields as
+        // `{"$ref": "#/$defs/..."}` with the definitions in its own `$defs`
+        // scope. The emitter drops schemars' wrapper but used to keep the
+        // `$ref`, leaving a dangling pointer that strict JSON Schema
+        // validators (ajv-cli, etc.) refuse to compile.
+        let schema = BaseEventV1::<()>::gts_schema_with_refs();
+
+        assert!(
+            schema.get("$defs").is_none(),
+            "emitted schema must not carry schemars' $defs wrapper:\n{}",
+            serde_json::to_string_pretty(&schema).unwrap()
+        );
+
+        let mut stack = vec![&schema];
+        while let Some(v) = stack.pop() {
+            match v {
+                serde_json::Value::Object(map) => {
+                    if let Some(serde_json::Value::String(s)) = map.get("$ref") {
+                        assert!(
+                            !s.starts_with("#/$defs/"),
+                            "dangling internal $ref left in emitted schema: {}\nfull schema:\n{}",
+                            s,
+                            serde_json::to_string_pretty(&schema).unwrap()
+                        );
+                    }
+                    for child in map.values() {
+                        stack.push(child);
+                    }
+                }
+                serde_json::Value::Array(arr) => {
+                    for child in arr {
+                        stack.push(child);
+                    }
+                }
+                _ => {}
+            }
+        }
+
+        let type_prop = schema
+            .get("properties")
+            .and_then(|p| p.get("type"))
+            .expect("BaseEventV1 must have a `type` property (renamed from event_type)");
+        assert!(
+            type_prop.get("$ref").is_none(),
+            "`type` property still contains a $ref pointer:\n{}",
+            serde_json::to_string_pretty(type_prop).unwrap()
+        );
+        assert_eq!(
+            type_prop.get("format").and_then(|v| v.as_str()),
+            Some("gts-schema-id"),
+            "`type` property should be the inlined GtsSchemaId fragment, got:\n{}",
+            serde_json::to_string_pretty(type_prop).unwrap()
+        );
+    }
+
+    #[test]
     fn test_schema_inheritance() {
         // Only base type can access schema methods directly
         // Multi-segment schemas are blocked from direct access

--- a/gts-macros/tests/inheritance_tests.rs
+++ b/gts-macros/tests/inheritance_tests.rs
@@ -2532,9 +2532,12 @@ mod tests {
 
     #[test]
     fn test_audit_payload_v1_schema_field_path() {
-        // AuditPayloadV1<()> is a GENERIC type - its own properties are at root level in allOf[1]
-        // (not nested under parent's generic field)
-        // Only non-generic children nest under parent's generic field
+        // AuditPayloadV1<()> is a generic derived type extending BaseEventV1.
+        // Its overlay properties live nested under the parent's generic field
+        // (`payload`), exactly like a non-generic derived type would — this
+        // keeps the GTS inheritance contract symmetric (§ 3.1: a derived
+        // schema must not introduce new properties at an object level where
+        // the base declares `additionalProperties: false`).
         let schema = AuditPayloadV1::<()>::gts_schema_with_refs();
         println!(
             "AuditPayloadV1 schema:\n{}",
@@ -2551,23 +2554,47 @@ mod tests {
         let all_of = schema.get("allOf").expect("Should have allOf");
         assert_eq!(all_of[0]["$ref"], "gts://gts.x.core.events.type.v1~");
 
-        // Generic type's own properties are at root level of allOf[1], not nested
+        // Properties land under parent's generic field ("payload").
         let child_schema = &all_of[1];
         let props = child_schema
             .get("properties")
             .expect("Should have properties");
+        let payload = props.get("payload").expect("Should nest under payload");
+        let payload_props = payload
+            .get("properties")
+            .expect("payload should have properties");
 
-        // Properties should be at root level (not nested under "payload")
-        assert!(props.get("user_agent").is_some(), "Should have user_agent");
-        assert!(props.get("user_id").is_some(), "Should have user_id");
-        assert!(props.get("ip_address").is_some(), "Should have ip_address");
+        // AuditPayloadV1's fields are nested inside `payload`.
         assert!(
-            props.get("data").is_some(),
-            "Should have data (generic field placeholder)"
+            payload_props.get("user_agent").is_some(),
+            "payload.properties should have user_agent"
+        );
+        assert!(
+            payload_props.get("user_id").is_some(),
+            "payload.properties should have user_id"
+        );
+        assert!(
+            payload_props.get("ip_address").is_some(),
+            "payload.properties should have ip_address"
+        );
+        assert!(
+            payload_props.get("data").is_some(),
+            "payload.properties should have data (next-level generic placeholder)"
         );
 
-        // data should be a simple {"type": "object"} placeholder for the generic field
-        assert_eq!(props["data"]["type"], "object");
+        // The nested `payload` wrap is closed.
+        assert_eq!(
+            payload["additionalProperties"], false,
+            "Nested payload should have additionalProperties: false"
+        );
+
+        // `data` (AuditPayloadV1's own generic slot) stays open, so the next
+        // derived level (e.g. PlaceOrderDataV1) can extend it.
+        assert_eq!(payload_props["data"]["type"], "object");
+        assert!(
+            payload_props["data"].get("additionalProperties").is_none(),
+            "data placeholder must remain open for further derivation"
+        );
     }
 
     #[test]
@@ -2593,32 +2620,38 @@ mod tests {
             "gts://gts.x.core.events.type.v1~x.core.audit.event.v1~"
         );
 
-        // Non-generic child's properties should be nested under parent's generic field ("data")
+        // PlaceOrderDataV1's properties land at the FULL nesting path from
+        // the document root: payload -> data. The earlier single-level wrap
+        // (just "data") would have put `data` at the top of the overlay,
+        // violating BaseEventV1's `additionalProperties: false`. Now derived
+        // overlays declare fields exactly where they live in the composed
+        // instance.
         let child_schema = &all_of[1];
-        let props = child_schema
-            .get("properties")
-            .expect("Should have properties");
-
-        // Should have "data" field (parent's generic field)
-        let data_prop = props.get("data").expect("Should have data property");
+        let data_prop = &child_schema["properties"]["payload"]["properties"]["data"];
         let data_props = data_prop
             .get("properties")
-            .expect("data should have properties");
+            .expect("payload.properties.data should have properties");
 
-        // Verify PlaceOrderDataV1's properties are nested under "data"
         assert!(
             data_props.get("order_id").is_some(),
-            "data.properties should have order_id"
+            "payload.data.properties should have order_id"
         );
         assert!(
             data_props.get("product_id").is_some(),
-            "data.properties should have product_id"
+            "payload.data.properties should have product_id"
         );
 
-        // Verify additionalProperties: false on nested data
+        // The deepest wrap (where current type's own fields live) carries
+        // `additionalProperties: false`. Outer wraps (payload) are passthrough.
         assert_eq!(
             data_prop["additionalProperties"], false,
-            "Nested data should have additionalProperties: false"
+            "Innermost wrap (data) should have additionalProperties: false"
+        );
+        assert!(
+            child_schema["properties"]["payload"]
+                .get("additionalProperties")
+                .is_none(),
+            "Outer wrap (payload) is a passthrough; AP:false belongs to the parent chain's own overlay"
         );
     }
 
@@ -2708,12 +2741,12 @@ mod tests {
 
     #[test]
     fn test_all_nested_schemas_have_additional_properties_false() {
-        // Verify all nested schemas have additionalProperties: false at the correct level
-        // Note: Generic types (like AuditPayloadV1<()>) have properties at root level of allOf[1],
-        // only non-generic children nest under parent's generic field
+        // Every derived overlay (generic or not) wraps its own properties
+        // inside the parent's generic field and closes that wrap with
+        // `additionalProperties: false`. The next-level generic slot inside
+        // that wrap stays open (a placeholder for further derivation).
 
         // Non-generic child: SimplePayloadV1 (extends BaseEventV1)
-        // Properties nested under "payload" (parent's generic field)
         let simple_schema = SimplePayloadV1::gts_schema_with_refs();
         let simple_payload = &simple_schema["allOf"][1]["properties"]["payload"];
         assert_eq!(
@@ -2721,28 +2754,37 @@ mod tests {
             "SimplePayloadV1 nested payload should have additionalProperties: false"
         );
 
-        // Generic type: AuditPayloadV1<()> - properties at root level of allOf[1]
-        // The "data" field is a generic placeholder, not a nested child
-        // So we don't check for additionalProperties on root level (it's not there for generic types)
+        // Generic derived: AuditPayloadV1<()> (extends BaseEventV1)
+        // Same shape as the non-generic case above — nested under `payload`,
+        // closed, with `data` left as an open placeholder for the next level.
         let audit_schema = AuditPayloadV1::<()>::gts_schema_with_refs();
-        let audit_props = &audit_schema["allOf"][1]["properties"];
-        // Verify "data" is a simple placeholder (no additionalProperties)
+        let audit_payload = &audit_schema["allOf"][1]["properties"]["payload"];
         assert_eq!(
-            audit_props["data"]["type"], "object",
+            audit_payload["additionalProperties"], false,
+            "AuditPayloadV1 nested payload should have additionalProperties: false"
+        );
+        assert_eq!(
+            audit_payload["properties"]["data"]["type"], "object",
             "AuditPayloadV1 data field should be a simple object placeholder"
         );
+        assert!(
+            audit_payload["properties"]["data"]
+                .get("additionalProperties")
+                .is_none(),
+            "data placeholder must remain open for further derivation"
+        );
 
-        // Non-generic child: PlaceOrderDataV1 (extends AuditPayloadV1)
-        // Properties nested under "data" (parent's generic field)
+        // Non-generic child: PlaceOrderDataV1 (extends AuditPayloadV1).
+        // Full nesting path is payload -> data; AP:false sits on the
+        // innermost (data) wrap where this type's own fields live.
         let order_schema = PlaceOrderDataV1::gts_schema_with_refs();
-        let order_data = &order_schema["allOf"][1]["properties"]["data"];
+        let order_data = &order_schema["allOf"][1]["properties"]["payload"]["properties"]["data"];
         assert_eq!(
             order_data["additionalProperties"], false,
             "PlaceOrderDataV1 nested data should have additionalProperties: false"
         );
 
         // Unit struct: OrderTopicConfigV1 (extends TopicV1)
-        // Properties nested under "config" (parent's generic field)
         let topic_schema = OrderTopicConfigV1::gts_schema_with_refs();
         let topic_config = &topic_schema["allOf"][1]["properties"]["config"];
         assert_eq!(

--- a/gts/src/ops.rs
+++ b/gts/src/ops.rs
@@ -3348,7 +3348,8 @@ mod tests {
     #[test]
     fn test_add_entity_validate_rejects_instance_with_schema_only_keyword() {
         // Registration with validate=true MUST reject an instance whose body
-        // contains schema-only keywords (x-gts-final / x-gts-abstract).
+        // contains schema-only keywords (x-gts-final / x-gts-abstract /
+        // x-gts-traits-schema / x-gts-traits).
         let mut ops = GtsOps::new(None, None, 0);
 
         let schema = json!({
@@ -3372,6 +3373,73 @@ mod tests {
         );
         assert!(
             result.error.contains("x-gts-final"),
+            "error should name the offending keyword, got: {}",
+            result.error
+        );
+    }
+
+    #[test]
+    fn test_add_entity_validate_rejects_instance_with_traits_keyword() {
+        // Per GTS spec § 9.7.1, x-gts-traits is a schema-only keyword and MUST
+        // be rejected when present in an instance body.
+        let mut ops = GtsOps::new(None, None, 0);
+
+        let schema = json!({
+            "$id": "gts://gts.x.testtrkw.host.thing.v1~",
+            "$schema": "http://json-schema.org/draft-07/schema#",
+            "type": "object",
+            "properties": {"name": {"type": "string"}},
+            "required": ["name"],
+        });
+        assert!(ops.add_entity(&schema, false).ok);
+
+        let bad_instance = json!({
+            "id": "gts.x.testtrkw.host.thing.v1~x.testtrkw._.item.v1",
+            "name": "leak",
+            "x-gts-traits": {"retention": "P30D"},
+        });
+        let result = ops.add_entity(&bad_instance, true);
+        assert!(
+            !result.ok,
+            "instance with x-gts-traits keyword must be rejected"
+        );
+        assert!(
+            result.error.contains("x-gts-traits"),
+            "error should name the offending keyword, got: {}",
+            result.error
+        );
+    }
+
+    #[test]
+    fn test_add_entity_validate_rejects_instance_with_traits_schema_keyword() {
+        // Per GTS spec § 9.7.1, x-gts-traits-schema is a schema-only keyword
+        // and MUST be rejected when present in an instance body.
+        let mut ops = GtsOps::new(None, None, 0);
+
+        let schema = json!({
+            "$id": "gts://gts.x.testtskw.host.thing.v1~",
+            "$schema": "http://json-schema.org/draft-07/schema#",
+            "type": "object",
+            "properties": {"name": {"type": "string"}},
+            "required": ["name"],
+        });
+        assert!(ops.add_entity(&schema, false).ok);
+
+        let bad_instance = json!({
+            "id": "gts.x.testtskw.host.thing.v1~x.testtskw._.item.v1",
+            "name": "leak",
+            "x-gts-traits-schema": {
+                "type": "object",
+                "properties": {"retention": {"type": "string"}},
+            },
+        });
+        let result = ops.add_entity(&bad_instance, true);
+        assert!(
+            !result.ok,
+            "instance with x-gts-traits-schema keyword must be rejected"
+        );
+        assert!(
+            result.error.contains("x-gts-traits-schema"),
             "error should name the offending keyword, got: {}",
             result.error
         );

--- a/gts/src/schema.rs
+++ b/gts/src/schema.rs
@@ -79,6 +79,32 @@ pub trait GtsSchema {
         Vec::new()
     }
 
+    /// Path of generic-slot field names from the document root (the
+    /// outermost base type in the chain) down to where this type's own
+    /// properties live in a composed instance.
+    ///
+    /// For a base type (no parent): `[]`.
+    /// For each derived level: parent's path plus the parent's
+    /// `GENERIC_FIELD`. So for the chain
+    /// `BaseEventV1<P> -> AuditPayloadV1<D> -> PlaceOrderDataV1<E> -> PlaceOrderDataPayloadV1`:
+    ///
+    /// | Type | `outer_generic_path()` |
+    /// |---|---|
+    /// | `BaseEventV1` | `[]` |
+    /// | `AuditPayloadV1` | `["payload"]` |
+    /// | `PlaceOrderDataV1` | `["payload", "data"]` |
+    /// | `PlaceOrderDataPayloadV1` | `["payload", "data", "last"]` |
+    ///
+    /// Used by derived emitters to wrap their overlay properties at the
+    /// correct depth, so a derived schema's `allOf` overlay declares its
+    /// fields nested under the parent chain's generic slots rather than
+    /// at the top level (which would violate the base's
+    /// `additionalProperties: false` per gts-spec sec 3.1).
+    #[must_use]
+    fn outer_generic_path() -> Vec<&'static str> {
+        Vec::new()
+    }
+
     /// Wrap properties in a nested structure following the nesting path.
     /// For path `["payload", "data"]` and properties `{order_id, product_id, last}`,
     /// returns `{ "payload": { "type": "object", "properties": { "data": { "type": "object", "additionalProperties": false, "properties": {...}, "required": [...] } } } }`

--- a/gts/src/schema_modifiers.rs
+++ b/gts/src/schema_modifiers.rs
@@ -1,7 +1,19 @@
 use serde_json::Value;
 
+use crate::schema_traits::{X_GTS_TRAITS, X_GTS_TRAITS_SCHEMA};
+
 pub const X_GTS_FINAL: &str = "x-gts-final";
 pub const X_GTS_ABSTRACT: &str = "x-gts-abstract";
+
+/// All `x-gts-*` keywords that are valid only on JSON Schema documents and
+/// MUST be rejected when found inside instance documents (GTS spec § 9.7.1,
+/// § 9.11.1).
+const SCHEMA_ONLY_KEYWORDS: &[&str] = &[
+    X_GTS_FINAL,
+    X_GTS_ABSTRACT,
+    X_GTS_TRAITS_SCHEMA,
+    X_GTS_TRAITS,
+];
 
 fn contains_key_recursive(value: &Value, key: &str) -> bool {
     match value {
@@ -60,21 +72,22 @@ pub fn validate_schema_modifiers(content: &Value) -> Result<(), String> {
     Ok(())
 }
 
-/// Check that schema-only keywords (`x-gts-final`, `x-gts-abstract`) do not appear anywhere
-/// in instance content.
+/// Check that schema-only keywords (`x-gts-final`, `x-gts-abstract`,
+/// `x-gts-traits-schema`, `x-gts-traits`) do not appear anywhere in instance
+/// content. Per GTS spec § 9.7.1 and § 9.11.1 these annotations are only
+/// valid on JSON Schema documents and implementations MUST reject instances
+/// that contain them.
 ///
 /// # Errors
-/// Returns error if any schema-only keyword is found in the content (top-level or nested).
+/// Returns an error naming the first schema-only keyword found in the content
+/// (top-level or nested).
 pub fn validate_instance_modifiers(content: &Value) -> Result<(), String> {
-    if contains_key_recursive(content, X_GTS_FINAL) {
-        return Err(format!(
-            "{X_GTS_FINAL} is a schema-only keyword and must not appear in instances"
-        ));
-    }
-    if contains_key_recursive(content, X_GTS_ABSTRACT) {
-        return Err(format!(
-            "{X_GTS_ABSTRACT} is a schema-only keyword and must not appear in instances"
-        ));
+    for keyword in SCHEMA_ONLY_KEYWORDS {
+        if contains_key_recursive(content, keyword) {
+            return Err(format!(
+                "{keyword} is a schema-only keyword and must not appear in instances"
+            ));
+        }
     }
     Ok(())
 }
@@ -268,6 +281,42 @@ mod tests {
         }));
         assert!(result.is_err());
         assert!(result.unwrap_err().contains("x-gts-abstract"));
+    }
+
+    #[test]
+    fn test_instance_has_traits_rejected() {
+        let result = validate_instance_modifiers(&json!({
+            "id": "test",
+            "x-gts-traits": {"retention": "P30D"},
+        }));
+        assert!(result.is_err());
+        let msg = result.unwrap_err();
+        assert!(msg.contains("x-gts-traits"), "msg: {msg}");
+        assert!(msg.contains("schema-only"), "msg: {msg}");
+    }
+
+    #[test]
+    fn test_instance_has_traits_schema_rejected() {
+        let result = validate_instance_modifiers(&json!({
+            "id": "test",
+            "x-gts-traits-schema": {
+                "type": "object",
+                "properties": {"retention": {"type": "string"}},
+            },
+        }));
+        assert!(result.is_err());
+        let msg = result.unwrap_err();
+        assert!(msg.contains("x-gts-traits-schema"), "msg: {msg}");
+    }
+
+    #[test]
+    fn test_instance_nested_traits_rejected() {
+        let result = validate_instance_modifiers(&json!({
+            "id": "test",
+            "metadata": {"x-gts-traits": {"foo": "bar"}},
+        }));
+        assert!(result.is_err());
+        assert!(result.unwrap_err().contains("x-gts-traits"));
     }
 
     // =========================================================================

--- a/gts/src/schema_traits.rs
+++ b/gts/src/schema_traits.rs
@@ -26,6 +26,16 @@
 
 use serde_json::Value;
 
+/// JSON Schema annotation keyword that defines the *shape* of trait properties
+/// available to a GTS type and its descendants. Schema-only — MUST NOT appear
+/// in instances (see GTS spec § 9.7.1).
+pub const X_GTS_TRAITS_SCHEMA: &str = "x-gts-traits-schema";
+
+/// JSON Schema annotation keyword that supplies concrete *values* for trait
+/// properties declared via [`X_GTS_TRAITS_SCHEMA`]. Schema-only — MUST NOT
+/// appear in instances (see GTS spec § 9.7.1).
+pub const X_GTS_TRAITS: &str = "x-gts-traits";
+
 /// Maximum recursion depth for traversing `allOf` nesting.
 /// Prevents stack overflow on deeply nested or maliciously crafted schemas.
 const MAX_RECURSION_DEPTH: usize = 64;
@@ -83,11 +93,10 @@ pub fn validate_effective_traits(
 
     if resolved_trait_schemas.is_empty() {
         if has_trait_values {
-            return Err(vec![
-                "x-gts-traits values provided but no x-gts-traits-schema is defined in the \
+            return Err(vec![format!(
+                "{X_GTS_TRAITS} values provided but no {X_GTS_TRAITS_SCHEMA} is defined in the \
                  inheritance chain"
-                    .to_owned(),
-            ]);
+            )]);
         }
         return Ok(());
     }
@@ -96,10 +105,10 @@ pub fn validate_effective_traits(
     for (i, ts) in resolved_trait_schemas.iter().enumerate() {
         // x-gts-traits-schema must not contain x-gts-traits
         if let Some(obj) = ts.as_object()
-            && obj.contains_key("x-gts-traits")
+            && obj.contains_key(X_GTS_TRAITS)
         {
             return Err(vec![format!(
-                "x-gts-traits-schema[{i}] contains 'x-gts-traits' \u{2014} \
+                "{X_GTS_TRAITS_SCHEMA}[{i}] contains '{X_GTS_TRAITS}' \u{2014} \
                  trait values must not appear inside a trait schema definition"
             )]);
         }
@@ -138,7 +147,7 @@ fn collect_trait_schema_recursive(value: &Value, out: &mut Vec<Value>, depth: us
         return;
     };
 
-    if let Some(ts) = obj.get("x-gts-traits-schema") {
+    if let Some(ts) = obj.get(X_GTS_TRAITS_SCHEMA) {
         out.push(ts.clone());
     }
 
@@ -172,7 +181,7 @@ fn collect_traits_recursive(
         return;
     };
 
-    if let Some(Value::Object(traits)) = obj.get("x-gts-traits") {
+    if let Some(Value::Object(traits)) = obj.get(X_GTS_TRAITS) {
         for (k, v) in traits {
             merged.insert(k.clone(), v.clone());
         }


### PR DESCRIPTION
  - Fix three regressions in `gts_schema_with_refs_allof`: emit `description` into the generated JSON, wrap derived overlays at the full root-to-here nesting path (not just the immediate parent), and resolve empty paths for generic-derived branches.
  - Inline `#/$defs/Gts{Instance,Schema}Id` refs in the generic-base emitter so strict JSON Schema validators can compile the document.
  - Reject schema-only `x-gts-traits[-schema]` keywords in instance documents per gts-spec §9.7.1, alongside the existing `x-gts-final` / `x-gts-abstract` checks.
  - Add `gts-macros-cli` README.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added comprehensive CLI documentation for running the tool and using dump functionality.

* **Bug Fixes**
  * Refined schema structure and property constraints; enhanced validation to restrict schema-only keywords in instance documents.
  * Updated JSON Schema definitions with improved nesting and stricter field requirements.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/GlobalTypeSystem/gts-rust/pull/87?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->