### PR TITLE
feat(schema): align compatibility checks with v0.13 semantics

### DIFF
--- a/gts-id/src/gts_id.rs
+++ b/gts-id/src/gts_id.rs
@@ -226,7 +226,7 @@ mod tests {
         assert_eq!(seg.package(), "core");
         assert_eq!(seg.namespace(), "events");
         assert_eq!(seg.type_name(), "event");
-        assert_eq!(seg.ver_major(), 1);
+        assert_eq!(seg.ver_major_opt(), Some(1));
         assert_eq!(seg.ver_minor(), Some(2));
     }
 
@@ -359,14 +359,14 @@ mod tests {
     #[test]
     fn test_gts_id_version_without_minor() {
         let id = GtsId::try_new(&gts_id("x.core.events.event.v1~")).expect("test");
-        assert_eq!(id.segments[0].ver_major(), 1);
+        assert_eq!(id.segments[0].ver_major_opt(), Some(1));
         assert_eq!(id.segments[0].ver_minor(), None);
     }
 
     #[test]
     fn test_gts_id_version_with_large_numbers() {
         let id = GtsId::try_new(&gts_id("x.core.events.event.v99.999~")).expect("test");
-        assert_eq!(id.segments[0].ver_major(), 99);
+        assert_eq!(id.segments[0].ver_major_opt(), Some(99));
         assert_eq!(id.segments[0].ver_minor(), Some(999));
     }
 

--- a/gts-id/src/gts_id_segment.rs
+++ b/gts-id/src/gts_id_segment.rs
@@ -72,15 +72,6 @@ impl GtsIdSegmentParts {
         &self.type_name
     }
 
-    /// The major version, or `0` when unspecified in a wildcard segment.
-    ///
-    /// Use [`Self::ver_major_opt`] when the distinction between an unspecified
-    /// version and a real `v0` matters.
-    #[must_use]
-    pub fn ver_major(&self) -> u32 {
-        self.ver_major.unwrap_or(0)
-    }
-
     /// The major version when one was specified.
     #[must_use]
     pub fn ver_major_opt(&self) -> Option<u32> {
@@ -205,15 +196,6 @@ impl GtsIdSegment {
     #[must_use]
     pub fn type_name(&self) -> &str {
         self.parts().map_or("", |p| &p.type_name)
-    }
-
-    /// The major version, or `0` for a UUID tail.
-    ///
-    /// Use [`Self::ver_major_opt`] when the distinction between an absent
-    /// version and a real `v0` matters.
-    #[must_use]
-    pub fn ver_major(&self) -> u32 {
-        self.parts().map_or(0, GtsIdSegmentParts::ver_major)
     }
 
     /// The major version when this is a named GTS segment.
@@ -344,18 +326,6 @@ impl GtsIdPatternSegment {
         match self {
             GtsIdPatternSegment::Segment(s) => s.type_name(),
             GtsIdPatternSegment::Wildcard(p) => &p.type_name,
-        }
-    }
-
-    /// The major version, or `0` when unspecified.
-    ///
-    /// Use [`Self::ver_major_opt`] when the distinction between an unspecified
-    /// version wildcard and a real `v0` matters.
-    #[must_use]
-    pub fn ver_major(&self) -> u32 {
-        match self {
-            GtsIdPatternSegment::Segment(s) => s.ver_major(),
-            GtsIdPatternSegment::Wildcard(p) => p.ver_major(),
         }
     }
 
@@ -661,7 +631,7 @@ mod tests {
         assert_eq!(parsed.package(), "core");
         assert_eq!(parsed.namespace(), "events");
         assert_eq!(parsed.type_name(), "event");
-        assert_eq!(parsed.ver_major(), 1);
+        assert_eq!(parsed.ver_major_opt(), Some(1));
         assert_eq!(parsed.ver_minor(), None);
         assert!(parsed.is_type());
     }
@@ -669,7 +639,7 @@ mod tests {
     #[test]
     fn test_valid_segment_with_minor() {
         let parsed = GtsIdSegment::parse(1, "x.core.events.event.v1.2~").unwrap();
-        assert_eq!(parsed.ver_major(), 1);
+        assert_eq!(parsed.ver_major_opt(), Some(1));
         assert_eq!(parsed.ver_minor(), Some(2));
     }
 
@@ -835,7 +805,7 @@ mod tests {
         assert_eq!(parsed.package(), "pkg");
         assert_eq!(parsed.namespace(), "ns");
         assert_eq!(parsed.type_name(), "type");
-        assert_eq!(parsed.ver_major(), 0);
+        assert_eq!(parsed.ver_major_opt(), None);
         assert_eq!(parsed.ver_minor(), None);
     }
 
@@ -882,7 +852,7 @@ mod tests {
         assert_eq!(seg.raw(), UUID_TAIL);
         assert!(!seg.is_type());
         assert_eq!(seg.vendor(), "");
-        assert_eq!(seg.ver_major(), 0);
+        assert_eq!(seg.ver_major_opt(), None);
         assert_eq!(seg.ver_minor(), None);
 
         #[cfg(feature = "uuid")]
@@ -920,7 +890,7 @@ mod tests {
         assert_eq!(parts.package(), "core");
         assert_eq!(parts.namespace(), "events");
         assert_eq!(parts.type_name(), "event");
-        assert_eq!(parts.ver_major(), 1);
+        assert_eq!(parts.ver_major_opt(), Some(1));
         assert_eq!(parts.ver_minor(), Some(2));
         assert!(parts.is_type());
     }

--- a/gts-macros/tests/additional_properties_tests.rs
+++ b/gts-macros/tests/additional_properties_tests.rs
@@ -1,0 +1,157 @@
+//! Behavioural assertions for the `additionalProperties` content model the
+//! macro emits, one pointer per level under test.
+//!
+//! These share the `additional_properties_*` fixtures with `golden_tests.rs`,
+//! which snapshot-matches whole documents. The snapshot cannot express *which*
+//! value is correct — `GTS_GOLDEN=overwrite` blesses whatever the macro emits —
+//! so the rule each fixture exists to prove is stated here instead. The
+//! fixtures are `include!`d rather than imported because every file under
+//! `tests/` is its own crate root, so a module declared in `golden_tests.rs` is
+//! not reachable from here.
+
+#![allow(clippy::unwrap_used, clippy::expect_used)]
+
+/// Declares the fixture modules this file asserts over.
+macro_rules! fixtures {
+    ($($name:ident),+ $(,)?) => {
+        $(
+            mod $name {
+                include!(concat!("golden/", stringify!($name), ".rs"));
+            }
+        )+
+    };
+}
+
+fixtures!(
+    additional_properties_nested_closed,
+    additional_properties_explicit_open,
+    additional_properties_flattened_map,
+    additional_properties_content_models,
+    additional_properties_gts_root_open,
+    additional_properties_gts_derived_open,
+);
+
+/// The `additionalProperties` value at `pointer` in the schema generated for
+/// `type_id`, or `"<absent>"` when the level states no content model.
+///
+/// `"<absent>"` is a distinct expectation, not a fallback: on a combinator
+/// branch or on a derived type's `allOf` wrapper, both `false` and `true` would
+/// be wrong and stating nothing is the correct output.
+#[track_caller]
+fn at(schemas: &[(String, serde_json::Value)], type_id: &str, pointer: &str) -> String {
+    let (_, schema) = schemas
+        .iter()
+        .find(|(id, _)| id == type_id)
+        .unwrap_or_else(|| panic!("case does not generate '{type_id}'"));
+    schema
+        .pointer(pointer)
+        .map_or_else(|| "<absent>".to_owned(), ToString::to_string)
+}
+
+/// Ordinary nested structs are closed at every level, including the Draft-07
+/// `definitions` the nested types land in.
+#[test]
+fn nested_structs_are_closed_at_every_level() {
+    let nested = additional_properties_nested_closed::schemas();
+    let nested_id = "gts.x.test.golden.nestedclosed.v1~";
+    for pointer in [
+        "/additionalProperties",
+        "/definitions/Profile/additionalProperties",
+        "/definitions/Contact/additionalProperties",
+    ] {
+        assert_eq!(at(&nested, nested_id, pointer), "false", "{pointer}");
+    }
+}
+
+/// An explicitly open nested struct keeps its own model while the GTS root stays
+/// closed - the opt-out applies where it is declared, not upward.
+#[test]
+fn an_explicit_open_level_does_not_open_the_root() {
+    let open = additional_properties_explicit_open::schemas();
+    let open_id = "gts.x.test.golden.explicitopen.v1~";
+    assert_eq!(at(&open, open_id, "/additionalProperties"), "false");
+    assert_eq!(
+        at(
+            &open,
+            open_id,
+            "/definitions/ExtensionPoint/additionalProperties"
+        ),
+        "true"
+    );
+}
+
+/// A flattened map is the same thing spelled through Serde.
+#[test]
+fn a_flattened_map_level_stays_open() {
+    let map = additional_properties_flattened_map::schemas();
+    let map_id = "gts.x.test.golden.flattenedmap.v1~";
+    assert_eq!(at(&map, map_id, "/additionalProperties"), "false");
+    assert_eq!(
+        at(
+            &map,
+            map_id,
+            "/definitions/ExtensibleMetadata/additionalProperties"
+        ),
+        "true"
+    );
+}
+
+/// A schema-valued map level keeps its value constraint, and combinator branches
+/// are left alone - closing them would reject instances a sibling branch accepts.
+#[test]
+fn map_value_constraints_and_combinator_branches_are_preserved() {
+    let models = additional_properties_content_models::schemas();
+    let models_id = "gts.x.test.golden.contentmodels.v1~";
+    assert_eq!(at(&models, models_id, "/additionalProperties"), "false");
+    assert_eq!(
+        at(
+            &models,
+            models_id,
+            "/properties/labels/additionalProperties"
+        ),
+        r#"{"type":"string"}"#
+    );
+    for branch in ["0", "1"] {
+        assert_eq!(
+            at(
+                &models,
+                models_id,
+                &format!("/definitions/Choice/anyOf/{branch}/additionalProperties"),
+            ),
+            "<absent>",
+        );
+    }
+}
+
+/// On a GTS base type the explicit open model applies to the root itself.
+#[test]
+fn a_gts_base_type_can_declare_its_root_open() {
+    assert_eq!(
+        at(
+            &additional_properties_gts_root_open::schemas(),
+            "gts.x.test.golden.rootopen.v1~",
+            "/additionalProperties",
+        ),
+        "true"
+    );
+}
+
+/// On a derived type it applies to the level carrying that type's own fields,
+/// not to the `allOf` wrapper - a model on the wrapper would fight the parent's.
+#[test]
+fn a_derived_type_opens_its_own_field_level_not_the_wrapper() {
+    let derived = additional_properties_gts_derived_open::schemas();
+    let derived_id = "gts.x.test.golden.openchain.v1~x.test.audit.payload.v1~";
+    assert_eq!(
+        at(&derived, derived_id, "/additionalProperties"),
+        "<absent>"
+    );
+    assert_eq!(
+        at(
+            &derived,
+            derived_id,
+            "/allOf/1/properties/payload/additionalProperties"
+        ),
+        "true"
+    );
+}

--- a/gts-macros/tests/integration_tests.rs
+++ b/gts-macros/tests/integration_tests.rs
@@ -731,7 +731,7 @@ fn test_gts_id_segments_match_schema() {
     assert_eq!(segment.package(), "core");
     assert_eq!(segment.namespace(), "events");
     assert_eq!(segment.type_name(), "topic");
-    assert_eq!(segment.ver_major(), 1);
+    assert_eq!(segment.ver_major_opt(), Some(1));
     assert!(
         segment.is_type(),
         "Schema ID should be a type (ends with ~)"
@@ -759,7 +759,7 @@ fn test_gts_id_segments_match_instance() {
     assert_eq!(type_segment.package(), "core");
     assert_eq!(type_segment.namespace(), "events");
     assert_eq!(type_segment.type_name(), "topic");
-    assert_eq!(type_segment.ver_major(), 1);
+    assert_eq!(type_segment.ver_major_opt(), Some(1));
     assert!(type_segment.is_type(), "First segment should be a type");
 
     // Second segment is the instance segment
@@ -768,7 +768,7 @@ fn test_gts_id_segments_match_instance() {
     assert_eq!(instance_segment.package(), "commerce");
     assert_eq!(instance_segment.namespace(), "orders");
     assert_eq!(instance_segment.type_name(), "orders");
-    assert_eq!(instance_segment.ver_major(), 1);
+    assert_eq!(instance_segment.ver_major_opt(), Some(1));
     assert_eq!(instance_segment.ver_minor(), Some(0));
 }
 
@@ -796,8 +796,8 @@ fn test_schema_and_instance_segments_relationship() {
         instance_type_segment.type_name()
     );
     assert_eq!(
-        schema_segment.ver_major(),
-        instance_type_segment.ver_major()
+        schema_segment.ver_major_opt(),
+        instance_type_segment.ver_major_opt()
     );
 
     // get_type_id() should return the schema ID (without the instance segment)
@@ -849,7 +849,7 @@ fn test_entity_and_gts_id_vendor_package_namespace_match() {
         assert_eq!(entity_seg.package(), direct_seg.package());
         assert_eq!(entity_seg.namespace(), direct_seg.namespace());
         assert_eq!(entity_seg.type_name(), direct_seg.type_name());
-        assert_eq!(entity_seg.ver_major(), direct_seg.ver_major());
+        assert_eq!(entity_seg.ver_major_opt(), direct_seg.ver_major_opt());
         assert_eq!(entity_seg.ver_minor(), direct_seg.ver_minor());
         assert_eq!(entity_seg.is_type(), direct_seg.is_type());
     }

--- a/gts/src/ops.rs
+++ b/gts/src/ops.rs
@@ -43,15 +43,16 @@ pub struct GtsIdSegmentInfo {
 
 impl From<&crate::gts::GtsIdSegment> for GtsIdSegmentInfo {
     fn from(seg: &crate::gts::GtsIdSegment) -> Self {
-        // A concrete segment always carries a real major version (including a
-        // legitimate `v0`), so `ver_major` is never the wildcard "unspecified"
-        // sentinel here.
+        // A *named* concrete segment always carries a real major version,
+        // including a legitimate `v0`. A UUID-tail segment carries none at all,
+        // and reporting that as `v0` would be the same conflation the pattern
+        // matcher had to stop making, so the absence is passed through.
         Self {
             vendor: seg.vendor().to_owned(),
             package: seg.package().to_owned(),
             namespace: seg.namespace().to_owned(),
             type_name: seg.type_name().to_owned(),
-            ver_major: Some(seg.ver_major()),
+            ver_major: seg.ver_major_opt(),
             ver_minor: seg.ver_minor(),
             is_type: seg.is_type(),
         }
@@ -822,6 +823,22 @@ mod tests {
         let result = GtsOps::parse_id("invalid");
         assert!(result.segments.is_empty());
         assert!(!result.error.is_empty());
+    }
+
+    /// A UUID-tail segment carries no version at all, so it must report
+    /// absence rather than a `v0` it never declared - the same conflation
+    /// `GtsIdPattern::matches_views` had to stop making.
+    #[test]
+    fn test_parse_id_uuid_tail_has_no_major_version() {
+        let result =
+            GtsOps::parse_id("gts.x.core.events.event.v1~7a1d2f34-5678-49ab-9012-abcdef123456");
+        assert!(result.ok, "{:?}", result.error);
+        assert_eq!(result.segments.len(), 2);
+        assert_eq!(result.segments[0].ver_major, Some(1));
+        assert_eq!(
+            result.segments[1].ver_major, None,
+            "a UUID tail must not claim v0"
+        );
     }
 
     #[test]
@@ -1813,8 +1830,8 @@ mod tests {
             incompatibility_reasons: vec![],
             backward_errors: vec![],
             forward_errors: vec![],
-            specification_version: crate::GTS_SPECIFICATION_VERSION.to_owned(),
-            implementation_version: crate::GTS_IMPLEMENTATION_VERSION.to_owned(),
+            specification_version: Some(crate::GTS_SPECIFICATION_VERSION.to_owned()),
+            implementation_version: Some(crate::GTS_IMPLEMENTATION_VERSION.to_owned()),
             casted_entity: Some(json!({"name": "test"})),
             error: None,
         };

--- a/gts/src/schema_cast.rs
+++ b/gts/src/schema_cast.rs
@@ -23,6 +23,7 @@ pub enum SchemaCastError {
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
+#[must_use = "the compatibility verdict must be inspected"]
 pub struct GtsEntityCastResult {
     #[serde(rename = "from")]
     pub from_id: String,
@@ -40,19 +41,30 @@ pub struct GtsEntityCastResult {
     pub incompatibility_reasons: Vec<String>,
     pub backward_errors: Vec<String>,
     pub forward_errors: Vec<String>,
-    #[serde(default = "specification_version")]
-    pub specification_version: String,
-    #[serde(default = "implementation_version")]
-    pub implementation_version: String,
+    /// Spec version of the implementation that *produced* this result, absent
+    /// when the payload it was read from did not carry one.
+    ///
+    /// Deliberately not defaulted to this build's constants: a result produced
+    /// by an older or foreign implementation would then silently claim our
+    /// versions, destroying the provenance these two fields exist to record.
+    #[serde(default)]
+    pub specification_version: Option<String>,
+    /// Version of the implementation that *produced* this result; see
+    /// [`Self::specification_version`] for why an absent value stays absent.
+    #[serde(default)]
+    pub implementation_version: Option<String>,
     pub casted_entity: Option<Value>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub error: Option<String>,
 }
 
+/// The spec version to stamp on a result produced by *this* build. Wrapped in
+/// `Some` at each use, so a result read from elsewhere can stay unstamped.
 fn specification_version() -> String {
     crate::GTS_SPECIFICATION_VERSION.to_owned()
 }
 
+/// The implementation version to stamp on a result produced by *this* build.
 fn implementation_version() -> String {
     crate::GTS_IMPLEMENTATION_VERSION.to_owned()
 }
@@ -87,8 +99,8 @@ impl GtsEntityCastResult {
             incompatibility_reasons: Vec::new(),
             backward_errors: Vec::new(),
             forward_errors: Vec::new(),
-            specification_version: specification_version(),
-            implementation_version: implementation_version(),
+            specification_version: Some(specification_version()),
+            implementation_version: Some(implementation_version()),
             casted_entity: None,
             error: Some(message.into()),
         }
@@ -147,8 +159,8 @@ impl GtsEntityCastResult {
                         incompatibility_reasons: vec![e.to_string()],
                         backward_errors,
                         forward_errors,
-                        specification_version: specification_version(),
-                        implementation_version: implementation_version(),
+                        specification_version: Some(specification_version()),
+                        implementation_version: Some(implementation_version()),
                         casted_entity: None,
                         error: None,
                     });
@@ -182,8 +194,8 @@ impl GtsEntityCastResult {
             incompatibility_reasons: reasons,
             backward_errors,
             forward_errors,
-            specification_version: specification_version(),
-            implementation_version: implementation_version(),
+            specification_version: Some(specification_version()),
+            implementation_version: Some(implementation_version()),
             casted_entity: Some(Value::Object(casted)),
             error: None,
         })
@@ -441,12 +453,12 @@ mod tests {
         assert!(result.backward_errors.is_empty());
         assert!(result.forward_errors.is_empty());
         assert_eq!(
-            result.specification_version,
-            crate::GTS_SPECIFICATION_VERSION
+            result.specification_version.as_deref(),
+            Some(crate::GTS_SPECIFICATION_VERSION)
         );
         assert_eq!(
-            result.implementation_version,
-            crate::GTS_IMPLEMENTATION_VERSION
+            result.implementation_version.as_deref(),
+            Some(crate::GTS_IMPLEMENTATION_VERSION)
         );
         assert!(result.casted_entity.is_none());
         assert_eq!(result.error.as_deref(), Some("could not decide"));
@@ -492,8 +504,8 @@ mod tests {
             incompatibility_reasons: vec![],
             backward_errors: vec![],
             forward_errors: vec![],
-            specification_version: specification_version(),
-            implementation_version: implementation_version(),
+            specification_version: Some(specification_version()),
+            implementation_version: Some(implementation_version()),
             casted_entity: None,
             error: None,
         };
@@ -519,6 +531,34 @@ mod tests {
         assert_eq!(
             json.get("implementation_version").and_then(Value::as_str),
             Some(crate::GTS_IMPLEMENTATION_VERSION)
+        );
+    }
+
+    /// A result read back from a payload that carries no versions must not
+    /// acquire this build's, or the provenance the two fields exist to record
+    /// is replaced by a claim nobody made.
+    #[test]
+    fn test_absent_versions_are_not_stamped_on_deserialization() {
+        let mut payload = serde_json::to_value(GtsEntityCastResult::undecided(
+            "gts.vendor.pkg.ns.type.v1.0",
+            "gts.vendor.pkg.ns.type.v2.0",
+            "produced elsewhere",
+        ))
+        .expect("test");
+        let object = payload.as_object_mut().expect("test");
+        object.remove("specification_version");
+        object.remove("implementation_version");
+
+        let foreign: GtsEntityCastResult = serde_json::from_value(payload).expect("test");
+        assert_eq!(foreign.specification_version, None);
+        assert_eq!(foreign.implementation_version, None);
+
+        // A locally produced result still stamps them, so the wire format of
+        // our own output is unchanged.
+        let local = GtsEntityCastResult::undecided("a", "b", "produced here");
+        assert_eq!(
+            local.specification_version.as_deref(),
+            Some(crate::GTS_SPECIFICATION_VERSION)
         );
     }
 

--- a/gts/src/schema_derivation.rs
+++ b/gts/src/schema_derivation.rs
@@ -13,11 +13,11 @@
 //! [`crate::schema_evolution`] and adds the two admission rules that inclusion alone
 //! does not express.
 
-use crate::schema_evolution::{CompatibilityFinding, check_accepted_set_inclusion, flatten_schema};
+use crate::schema_evolution::{
+    CompatibilityFinding, MAX_RECURSION_DEPTH, check_accepted_set_inclusion, flatten_schema,
+};
 use crate::schema_semantics::boolean_schema_value;
 use serde_json::Value;
-
-const MAX_RECURSION_DEPTH: usize = 64;
 
 const ADDITIONAL_PROPERTIES: &str = "additionalProperties";
 
@@ -66,8 +66,8 @@ pub(crate) fn validate_derivation(
     base_id: &str,
     derived_id: &str,
 ) -> Vec<String> {
-    let base = declared_schema(base_schema);
-    let mut derived = declared_schema(derived_schema);
+    let base = declared_schema(base_schema, 0);
+    let mut derived = declared_schema(derived_schema, 0);
     let mut errors = Vec::new();
 
     // An omitted `additionalProperties` is not a declaration: across dialects
@@ -124,21 +124,28 @@ pub(crate) fn validate_derivation(
 /// intersection with the base. `additionalProperties` is the exception: it
 /// folds through the closedness-preserving lattice, because a permissive
 /// overlay cannot reopen a branch that closed the level.
-fn declared_schema(schema: &Value) -> Value {
+///
+/// Below [`MAX_RECURSION_DEPTH`] the schema is returned as authored. Admission
+/// fails closed, so the shared checker reads an unreduced declaration as looser
+/// than it is and rejects the derivation rather than admitting it unchecked.
+fn declared_schema(schema: &Value, depth: usize) -> Value {
     let Some(map) = schema.as_object() else {
         return schema.clone();
     };
+    if depth >= MAX_RECURSION_DEPTH {
+        return schema.clone();
+    }
     let mut declared = serde_json::Map::new();
     let mut additional_properties = None;
 
     if let Some(branches) = map.get("allOf").and_then(Value::as_array) {
         for branch in branches {
-            if let Some(branch) = declared_schema(branch).as_object() {
-                absorb_declaration(&mut declared, &mut additional_properties, branch);
+            if let Some(branch) = declared_schema(branch, depth + 1).as_object() {
+                absorb_declaration(&mut declared, &mut additional_properties, branch, depth);
             }
         }
     }
-    absorb_declaration(&mut declared, &mut additional_properties, map);
+    absorb_declaration(&mut declared, &mut additional_properties, map, depth);
 
     if let Some(additional_properties) = additional_properties {
         declared.insert(ADDITIONAL_PROPERTIES.to_owned(), additional_properties);
@@ -151,6 +158,7 @@ fn absorb_declaration(
     declared: &mut serde_json::Map<String, Value>,
     additional_properties: &mut Option<Value>,
     source: &serde_json::Map<String, Value>,
+    depth: usize,
 ) {
     for (keyword, value) in source {
         match keyword.as_str() {
@@ -164,9 +172,9 @@ fn absorb_declaration(
                     .or_insert_with(|| Value::Object(serde_json::Map::new()));
                 if let (Some(target), Some(source)) = (target.as_object_mut(), value.as_object()) {
                     for (name, property) in source {
-                        let property = declared_schema(property);
+                        let property = declared_schema(property, depth + 1);
                         match target.get_mut(name) {
-                            Some(inherited) => absorb_property(inherited, &property),
+                            Some(inherited) => absorb_property(inherited, &property, depth + 1),
                             None => {
                                 target.insert(name.clone(), property);
                             }
@@ -206,12 +214,16 @@ const STRUCTURAL_KEYWORDS: &[&str] = &["properties", "required", ADDITIONAL_PROP
 /// `additionalProperties` of the base still apply through `allOf`, so an
 /// overlay that specifies a nested object without repeating its `required` list
 /// is not loosening anything.
-fn absorb_property(inherited: &mut Value, overlay: &Value) {
+fn absorb_property(inherited: &mut Value, overlay: &Value, depth: usize) {
     let (Some(inherited_map), Some(overlay_map)) = (inherited.as_object(), overlay.as_object())
     else {
         *inherited = overlay.clone();
         return;
     };
+    if depth >= MAX_RECURSION_DEPTH {
+        *inherited = overlay.clone();
+        return;
+    }
 
     let mut composed: serde_json::Map<String, Value> = overlay_map
         .iter()
@@ -224,7 +236,12 @@ fn absorb_property(inherited: &mut Value, overlay: &Value) {
             composed.insert(keyword.to_owned(), value.clone());
         }
     }
-    absorb_declaration(&mut composed, &mut additional_properties, overlay_map);
+    absorb_declaration(
+        &mut composed,
+        &mut additional_properties,
+        overlay_map,
+        depth,
+    );
     if let Some(additional_properties) = additional_properties {
         composed.insert(ADDITIONAL_PROPERTIES.to_owned(), additional_properties);
     }
@@ -263,16 +280,14 @@ fn collect_disabled_base_properties(
     derived_id: &str,
     errors: &mut Vec<String>,
 ) {
-    let effective_properties = |schema: &Value| {
-        flatten_schema(schema)
-            .get("properties")
-            .and_then(Value::as_object)
-            .cloned()
-            .unwrap_or_default()
-    };
-    let base_properties = effective_properties(base_schema);
-    for (name, derived_property) in effective_properties(derived_schema) {
-        if derived_property == Value::Bool(false) && base_properties.contains_key(&name) {
+    let base_flat = flatten_schema(base_schema);
+    let derived_flat = flatten_schema(derived_schema);
+    let base_properties = base_flat.get("properties").and_then(Value::as_object);
+    let derived_properties = derived_flat.get("properties").and_then(Value::as_object);
+    for (name, derived_property) in derived_properties.into_iter().flatten() {
+        if *derived_property == Value::Bool(false)
+            && base_properties.is_some_and(|properties| properties.contains_key(name))
+        {
             errors.push(format!(
                 "property '{name}': derived schema '{derived_id}' disables property defined in \
                 base '{base_id}'"
@@ -297,7 +312,7 @@ pub(crate) fn validate_closed_descendant_branches(
 ) -> Vec<String> {
     let mut errors = Vec::new();
     collect_closed_descendant_branch_errors(
-        ancestor_schema,
+        &flatten_schema(ancestor_schema),
         descendant_schema,
         "",
         0,
@@ -308,8 +323,11 @@ pub(crate) fn validate_closed_descendant_branches(
     errors
 }
 
+/// `ancestor` is already flattened: every `allOf` branch of the descendant is
+/// compared against the same ancestor level, so flattening here would redo the
+/// identical merge once per branch at every depth.
 fn collect_closed_descendant_branch_errors(
-    ancestor_schema: &Value,
+    ancestor: &Value,
     descendant_schema: &Value,
     path: &str,
     depth: usize,
@@ -326,7 +344,6 @@ fn collect_closed_descendant_branch_errors(
         return;
     }
 
-    let ancestor = flatten_schema(ancestor_schema);
     let ancestor_props = ancestor.get("properties").and_then(Value::as_object);
     let Some(descendant_obj) = descendant_schema.as_object() else {
         return;
@@ -373,7 +390,7 @@ fn collect_closed_descendant_branch_errors(
 
             let next_path = join_schema_path(path, name);
             collect_closed_descendant_branch_errors(
-                ancestor_prop,
+                &flatten_schema(ancestor_prop),
                 descendant_prop,
                 &next_path,
                 depth + 1,
@@ -387,7 +404,7 @@ fn collect_closed_descendant_branch_errors(
     if let Some(Value::Array(all_of)) = descendant_obj.get("allOf") {
         for item in all_of {
             collect_closed_descendant_branch_errors(
-                ancestor_schema,
+                ancestor,
                 item,
                 path,
                 depth + 1,

--- a/gts/src/schema_derivation_test.rs
+++ b/gts/src/schema_derivation_test.rs
@@ -1,6 +1,23 @@
 #![allow(clippy::unwrap_used, clippy::expect_used)]
 use super::*;
 use serde_json::json;
+/// Asserts that some error names both the offending location and the keyword
+/// the test is about.
+///
+/// Admission fails closed and turns every diagnostic - including
+/// `NotProvable` - into an error string, so a bare "the vector is not empty"
+/// passes on any undecidable result and proves nothing about the rule under
+/// test.
+#[track_caller]
+fn assert_reports(errors: &[String], path: &str, keyword: &str) {
+    assert!(
+        errors
+            .iter()
+            .any(|error| error.contains(path) && error.contains(keyword)),
+        "expected an error naming '{path}' and '{keyword}': {errors:?}"
+    );
+}
+
 // -- effective schema --------------------------------------------------
 
 /// Closedness must survive `allOf` composition: a permissive overlay may
@@ -135,6 +152,50 @@ fn test_compatible_tightening() {
     assert!(errs.is_empty(), "tightening should be ok: {errs:?}");
 }
 
+/// GTS pins no draft (spec sec 11), so a derivation may declare a newer dialect
+/// than the base it tightens - the dialect difference alone is not an admission
+/// failure.
+#[test]
+fn test_newer_dialect_alone_is_admitted() {
+    let base = json!({
+        "$schema": "http://json-schema.org/draft-07/schema#",
+        "type": "object",
+        "properties": {"v": {"type": "string", "maxLength": 100}}
+    });
+    let derived = json!({
+        "$schema": "https://json-schema.org/draft/2020-12/schema",
+        "type": "object",
+        "properties": {"v": {"type": "string", "maxLength": 50}}
+    });
+    let errs = validate_derivation_compatibility(&base, &derived, "base~", "derived~");
+    assert!(
+        errs.is_empty(),
+        "a newer dialect is not a failure: {errs:?}"
+    );
+}
+
+/// The exemption is scoped to the dialect diagnostic: a real violation
+/// alongside a dialect change is still reported.
+#[test]
+fn test_newer_dialect_does_not_excuse_loosening() {
+    let base = json!({
+        "$schema": "http://json-schema.org/draft-07/schema#",
+        "type": "object",
+        "properties": {"v": {"type": "string", "maxLength": 100}}
+    });
+    let derived = json!({
+        "$schema": "https://json-schema.org/draft/2020-12/schema",
+        "type": "object",
+        "properties": {"v": {"type": "string", "maxLength": 200}}
+    });
+    let errs = validate_derivation_compatibility(&base, &derived, "base~", "derived~");
+    assert_reports(&errs, "$.v", "maxLength");
+    assert!(
+        !errs.iter().any(|e| e.contains("dialect")),
+        "the dialect change itself must stay exempt: {errs:?}"
+    );
+}
+
 #[test]
 fn test_incompatible_loosening_max_length() {
     let base = json!({
@@ -150,7 +211,7 @@ fn test_incompatible_loosening_max_length() {
         }
     });
     let errs = validate_derivation_compatibility(&base, &derived, "base~", "derived~");
-    assert!(!errs.is_empty());
+    assert_reports(&errs, "$.v", "maxLength");
 }
 
 #[test]
@@ -168,7 +229,7 @@ fn test_incompatible_loosening_maximum() {
         }
     });
     let errs = validate_derivation_compatibility(&base, &derived, "b", "d");
-    assert!(!errs.is_empty());
+    assert_reports(&errs, "$.n", "maximum");
 }
 
 #[test]
@@ -186,7 +247,7 @@ fn test_incompatible_loosening_minimum() {
         }
     });
     let errs = validate_derivation_compatibility(&base, &derived, "b", "d");
-    assert!(!errs.is_empty());
+    assert_reports(&errs, "$.n", "minimum");
 }
 
 #[test]
@@ -204,7 +265,7 @@ fn test_enum_expansion_fails() {
         }
     });
     let errs = validate_derivation_compatibility(&base, &derived, "b", "d");
-    assert!(!errs.is_empty());
+    assert_reports(&errs, "$.s", "enum");
 }
 
 #[test]
@@ -240,7 +301,7 @@ fn test_additional_properties_false_blocks_new_prop() {
         }
     });
     let errs = validate_derivation_compatibility(&base, &derived, "b", "d");
-    assert!(!errs.is_empty());
+    assert_reports(&errs, "'b'", "closed");
 }
 
 #[test]
@@ -375,11 +436,12 @@ fn test_open_base_allows_new_prop() {
     assert!(errs.is_empty(), "{errs:?}");
 }
 
+/// The base declares no `required`, so switching the property off is the only
+/// thing the derivation changes and the only thing that may be reported.
 #[test]
 fn test_property_disabled_fails() {
     let base = json!({
         "type": "object",
-        "required": ["x"],
         "properties": {"x": {"type": "string"}}
     });
     let derived = json!({
@@ -387,7 +449,11 @@ fn test_property_disabled_fails() {
         "properties": {"x": false}
     });
     let errs = validate_derivation_compatibility(&base, &derived, "b", "d");
-    assert!(!errs.is_empty());
+    assert!(
+        errs.iter()
+            .any(|e| e.contains("disables property defined in") && e.contains("'x'")),
+        "{errs:?}"
+    );
 }
 
 #[test]
@@ -415,7 +481,7 @@ fn test_nested_object_loosening_caught() {
         }
     });
     let errs = validate_derivation_compatibility(&base, &derived, "b", "d");
-    assert!(!errs.is_empty());
+    assert_reports(&errs, "$.inner.v", "maximum");
 }
 
 #[test]
@@ -435,10 +501,7 @@ fn test_boolean_true_schema_loosens_constrained_property() {
         }
     });
     let errs = validate_derivation_compatibility(&base, &derived, "b", "d");
-    assert!(
-        !errs.is_empty(),
-        "Boolean true schema should be flagged as loosening: {errs:?}"
-    );
+    assert_reports(&errs, "$.age", "boolean schema");
 }
 
 #[test]
@@ -457,10 +520,7 @@ fn test_boolean_true_schema_loosens_typed_property() {
         }
     });
     let errs = validate_derivation_compatibility(&base, &derived, "b", "d");
-    assert!(
-        !errs.is_empty(),
-        "Boolean true schema replaces typed property - should flag"
-    );
+    assert_reports(&errs, "$.name", "boolean schema");
 }
 
 #[test]
@@ -547,10 +607,7 @@ fn test_omitting_bounds_without_enum_or_const_still_fails() {
         }
     });
     let errs = validate_derivation_compatibility(&base, &derived, "b", "d");
-    assert!(
-        !errs.is_empty(),
-        "Omitting maxLength without enum/const should still fail"
-    );
+    assert_reports(&errs, "$.code", "maxLength");
 }
 
 #[test]
@@ -578,7 +635,7 @@ fn test_derived_const_must_be_in_base_enum() {
         }
     });
     let errs = validate_derivation_compatibility(&base, &derived_bad, "b", "d");
-    assert!(!errs.is_empty(), "const NOT in base enum should fail");
+    assert_reports(&errs, "$.status", "enum");
 }
 
 #[test]
@@ -597,15 +654,7 @@ fn test_const_violates_minimum() {
         }
     });
     let errs = validate_derivation_compatibility(&base, &derived, "base~", "derived~");
-    assert!(
-        !errs.is_empty(),
-        "const 32 < minimum 42 should fail: {errs:?}"
-    );
-    assert!(
-        errs.iter()
-            .any(|e| e.contains("$.score") && e.contains("minimum")),
-        "error should name the offending property and constraint: {errs:?}"
-    );
+    assert_reports(&errs, "$.score", "minimum");
 }
 
 #[test]
@@ -646,10 +695,7 @@ fn test_enum_value_violates_maximum() {
         }
     });
     let errs = validate_derivation_compatibility(&base, &derived, "base~", "derived~");
-    assert!(
-        !errs.is_empty(),
-        "enum value 200 > maximum 100 should fail: {errs:?}"
-    );
+    assert_reports(&errs, "$.score", "maximum");
 }
 
 #[test]
@@ -690,8 +736,46 @@ fn test_const_string_violates_max_length() {
         }
     });
     let errs = validate_derivation_compatibility(&base, &derived, "base~", "derived~");
+    assert_reports(&errs, "$.code", "maxLength");
+}
+
+/// Admission must fail closed on a document nested past the shared bound.
+///
+/// `declared_schema` returns such a schema unreduced and `flatten_schema`
+/// stops merging its deepest branches, so the disabled-property rule alone
+/// could miss a violation down there. It never gets the chance: the bounded
+/// walks report the nesting first and every diagnostic becomes an error, so a
+/// derivation this deep is refused rather than admitted unchecked.
+#[test]
+fn test_derivation_nested_beyond_the_bound_is_refused() {
+    let nested_all_of = |leaf: Value| {
+        let mut schema = leaf;
+        for _ in 0..70 {
+            schema = json!({"allOf": [schema]});
+        }
+        schema
+    };
+    let base = nested_all_of(json!({"type": "object", "properties": {"x": {"type": "string"}}}));
+    // Disables a base property - the violation the shallow case reports by name.
+    let derived = nested_all_of(json!({"type": "object", "properties": {"x": false}}));
+
+    let errs = validate_derivation_compatibility(&base, &derived, "b", "d");
     assert!(
-        !errs.is_empty(),
-        "const 'toolong' exceeds maxLength 5: {errs:?}"
+        errs.iter().any(|error| error.contains("nesting depth")),
+        "the bound must be reported, not silently applied: {errs:?}"
+    );
+
+    // The same violation without the nesting is still named precisely, so the
+    // test above is about the bound and not about a broken rule.
+    let errs = validate_derivation_compatibility(
+        &json!({"type": "object", "properties": {"x": {"type": "string"}}}),
+        &json!({"type": "object", "properties": {"x": false}}),
+        "b",
+        "d",
+    );
+    assert!(
+        errs.iter()
+            .any(|error| error.contains("disables property defined in") && error.contains("'x'")),
+        "{errs:?}"
     );
 }

--- a/gts/src/schema_evolution.rs
+++ b/gts/src/schema_evolution.rs
@@ -15,7 +15,19 @@ use crate::schema_semantics::boolean_schema_value;
 use num_cmp::NumCmp;
 use serde::{Deserialize, Serialize};
 use serde_json::{Map, Value};
+use std::borrow::Cow;
+use std::cmp::Ordering;
 use std::collections::{BTreeSet, HashSet};
+
+/// Nesting depth at which every walk in this crate stops descending.
+///
+/// A single posted document cannot nest deeply enough to matter, but
+/// `$ref` resolution inlines other registered documents before any of these
+/// walks run, so the resolved tree can be far deeper than anything authored.
+/// Stopping is always reported - as `NotProvable` by the comparison walk and as
+/// an unproven location by the flattener - so a truncated walk never reads as a
+/// proof.
+pub(crate) const MAX_RECURSION_DEPTH: usize = 64;
 
 /// Result of attempting to establish one schema-compatibility relation.
 ///
@@ -57,16 +69,24 @@ impl CompatibilityVerdict {
     }
 
     /// Derives full compatibility from the two directional verdicts.
+    ///
+    /// Every pair is spelled out: a verdict added later must fail to compile
+    /// here rather than default to `Unknown`, which is a claim about the
+    /// relation and not the absence of one.
     #[must_use]
     pub const fn full(backward: Self, forward: Self) -> Self {
         match (backward, forward) {
             (Self::Compatible, Self::Compatible) => Self::Compatible,
-            (Self::Incompatible, _) | (_, Self::Incompatible) => Self::Incompatible,
-            _ => Self::Unknown,
+            (Self::Incompatible, Self::Compatible | Self::Incompatible | Self::Unknown)
+            | (Self::Compatible | Self::Unknown, Self::Incompatible) => Self::Incompatible,
+            (Self::Compatible | Self::Unknown, Self::Unknown)
+            | (Self::Unknown, Self::Compatible) => Self::Unknown,
         }
     }
 
-    fn from_diagnostics(diagnostics: &[CompatibilityDiagnostic]) -> Self {
+    /// Reads a verdict off its evidence: no diagnostics is a proof, only
+    /// inconclusive ones leave the relation undecided, anything else breaks it.
+    pub(crate) fn from_diagnostics(diagnostics: &[CompatibilityDiagnostic]) -> Self {
         if diagnostics.is_empty() {
             Self::Compatible
         } else if diagnostics
@@ -233,6 +253,28 @@ struct DialectSupport {
     new_unevaluated: bool,
 }
 
+/// What stays fixed for one directional comparison, plus how deep it has gone.
+#[derive(Debug, Clone, Copy)]
+struct Walk {
+    /// Backward checks `Valid(old) ⊆ Valid(new)`, forward the reverse inclusion.
+    check_backward: bool,
+    dialects: DialectSupport,
+    depth: usize,
+}
+
+impl Walk {
+    fn deeper(self) -> Self {
+        Self {
+            depth: self.depth + 1,
+            ..self
+        }
+    }
+
+    const fn exhausted(self) -> bool {
+        self.depth >= MAX_RECURSION_DEPTH
+    }
+}
+
 /// Narrows `unproven` to the locations inside `child`, rebased so that the
 /// empty string denotes `child` itself.
 fn unproven_below(unproven: &UnprovenPaths, child: &str) -> UnprovenPaths {
@@ -249,6 +291,28 @@ fn merge_schema_map(
     candidate: &Map<String, Value>,
     path: &str,
     unproven: &mut UnprovenPaths,
+    depth: usize,
+) {
+    for (keyword, candidate_value) in candidate {
+        merge_keyword(target, keyword, candidate_value, path, unproven, depth);
+    }
+}
+
+/// Intersects one keyword of a candidate branch into the accumulated level.
+///
+/// Separate from [`merge_schema_map`] because [`flatten_effective`] merges a
+/// level's own keywords while skipping its `allOf` - which it has already
+/// folded in - and a filtered copy of that map to hide one key would deep-copy
+/// the whole level. Nested `allOf` reached through a property is *not* skipped:
+/// it belongs to a subschema this pass does not flatten, and dropping it would
+/// silently weaken the level.
+fn merge_keyword(
+    target: &mut Map<String, Value>,
+    keyword: &str,
+    candidate_value: &Value,
+    path: &str,
+    unproven: &mut UnprovenPaths,
+    depth: usize,
 ) {
     const ANNOTATIONS: &[&str] = &[
         "$id",
@@ -284,99 +348,142 @@ fn merge_schema_map(
         "maxContains",
     ];
 
-    for (keyword, candidate_value) in candidate {
-        if ANNOTATIONS.contains(&keyword.as_str()) {
-            target.insert(keyword.clone(), candidate_value.clone());
-            continue;
-        }
-        let Some(current) = target.get_mut(keyword) else {
-            target.insert(keyword.clone(), candidate_value.clone());
-            continue;
-        };
-        if current == candidate_value {
-            continue;
-        }
+    if ANNOTATIONS.contains(&keyword) {
+        target.insert(keyword.to_owned(), candidate_value.clone());
+        return;
+    }
+    let Some(current) = target.get_mut(keyword) else {
+        target.insert(keyword.to_owned(), candidate_value.clone());
+        return;
+    };
+    if current == candidate_value {
+        return;
+    }
 
-        match keyword.as_str() {
-            "properties" | "patternProperties" => {
-                // The checker descends into named properties, so an unprovable
-                // property intersection stays local to that property. Pattern
-                // properties are compared as a node-level constraint instead.
-                let named = keyword == "properties";
-                if let (Some(current_map), Some(candidate_map)) =
-                    (current.as_object_mut(), candidate_value.as_object())
-                {
-                    for (name, candidate_schema) in candidate_map {
-                        if let Some(current_schema) = current_map.get_mut(name) {
-                            let property_path = if named {
-                                format!("{path}.{name}")
-                            } else {
-                                path.to_owned()
-                            };
-                            merge_schema_intersection(
-                                current_schema,
-                                candidate_schema,
-                                &property_path,
-                                unproven,
-                            );
+    match keyword {
+        "properties" | "patternProperties" => {
+            // The checker descends into named properties, so an unprovable
+            // property intersection stays local to that property. Pattern
+            // properties are compared as a node-level constraint instead.
+            let named = keyword == "properties";
+            if let (Some(current_map), Some(candidate_map)) =
+                (current.as_object_mut(), candidate_value.as_object())
+            {
+                for (name, candidate_schema) in candidate_map {
+                    if let Some(current_schema) = current_map.get_mut(name) {
+                        let property_path = if named {
+                            format!("{path}.{name}")
                         } else {
-                            current_map.insert(name.clone(), candidate_schema.clone());
-                        }
-                    }
-                } else {
-                    unproven.insert(path.to_owned());
-                }
-            }
-            "required" => {
-                if let (Some(current_items), Some(candidate_items)) =
-                    (current.as_array_mut(), candidate_value.as_array())
-                {
-                    for item in candidate_items {
-                        if !current_items.contains(item) {
-                            current_items.push(item.clone());
-                        }
+                            path.to_owned()
+                        };
+                        merge_schema_intersection(
+                            current_schema,
+                            candidate_schema,
+                            &property_path,
+                            unproven,
+                            depth + 1,
+                        );
+                    } else {
+                        current_map.insert(name.clone(), candidate_schema.clone());
                     }
                 }
-            }
-            "items" => {
-                merge_schema_intersection(current, candidate_value, &format!("{path}[]"), unproven);
-            }
-            "additionalProperties" | "unevaluatedProperties" | "propertyNames" | "contains" => {
-                merge_schema_intersection(current, candidate_value, path, unproven);
-            }
-            "enum" => {
-                if let (Some(current_values), Some(candidate_values)) =
-                    (current.as_array_mut(), candidate_value.as_array())
-                {
-                    current_values.retain(|value| candidate_values.contains(value));
-                    if current_values.is_empty() {
-                        unproven.insert(path.to_owned());
-                    }
-                }
-            }
-            keyword if MINIMUMS.contains(&keyword) => {
-                if candidate_value.as_f64() > current.as_f64() {
-                    *current = candidate_value.clone();
-                }
-            }
-            keyword if MAXIMUMS.contains(&keyword) => {
-                if candidate_value.as_f64() < current.as_f64() {
-                    *current = candidate_value.clone();
-                }
-            }
-            "type" => {
-                if current.as_str() == Some("number") && candidate_value.as_str() == Some("integer")
-                {
-                    *current = candidate_value.clone();
-                } else if !(current.as_str() == Some("integer")
-                    && candidate_value.as_str() == Some("number"))
-                {
-                    unproven.insert(path.to_owned());
-                }
-            }
-            _ => {
+            } else {
                 unproven.insert(path.to_owned());
             }
+        }
+        // `required` and `enum` are arrays in every dialect. A value that is
+        // not one carries a constraint this merge cannot represent, and
+        // keeping the accumulated side would claim an intersection nobody
+        // proved.
+        "required" => {
+            if let (Some(current_items), Some(candidate_items)) =
+                (current.as_array_mut(), candidate_value.as_array())
+            {
+                for item in candidate_items {
+                    if !current_items.contains(item) {
+                        current_items.push(item.clone());
+                    }
+                }
+            } else {
+                unproven.insert(path.to_owned());
+            }
+        }
+        "items" => {
+            merge_schema_intersection(
+                current,
+                candidate_value,
+                &format!("{path}[]"),
+                unproven,
+                depth + 1,
+            );
+        }
+        "additionalProperties" | "unevaluatedProperties" | "propertyNames" | "contains" => {
+            merge_schema_intersection(current, candidate_value, path, unproven, depth + 1);
+        }
+        "enum" => {
+            if let (Some(current_values), Some(candidate_values)) =
+                (current.as_array_mut(), candidate_value.as_array())
+            {
+                current_values.retain(|value| candidate_values.contains(value));
+                if current_values.is_empty() {
+                    unproven.insert(path.to_owned());
+                }
+            } else {
+                unproven.insert(path.to_owned());
+            }
+        }
+        // A bound is only ordered when both sides are numbers. Draft-04
+        // spells `exclusiveMinimum`/`exclusiveMaximum` as booleans that
+        // modify their sibling bound, and `Option<f64>` ordering would read
+        // that absent number as the weaker bound and drop the modifier.
+        keyword if MINIMUMS.contains(&keyword) => {
+            merge_numeric_bound(current, candidate_value, path, unproven, Ordering::Greater);
+        }
+        keyword if MAXIMUMS.contains(&keyword) => {
+            merge_numeric_bound(current, candidate_value, path, unproven, Ordering::Less);
+        }
+        "type" => {
+            if current.as_str() == Some("number") && candidate_value.as_str() == Some("integer") {
+                *current = candidate_value.clone();
+            } else if !(current.as_str() == Some("integer")
+                && candidate_value.as_str() == Some("number"))
+            {
+                unproven.insert(path.to_owned());
+            }
+        }
+        _ => {
+            unproven.insert(path.to_owned());
+        }
+    }
+}
+
+/// Keeps the tighter of two numeric bounds, or marks the location unprovable
+/// when either side is not a number or the pair cannot be ordered.
+///
+/// `tighter` is the ordering of candidate against held that means "adopt the
+/// candidate": [`Ordering::Greater`] for a minimum, [`Ordering::Less`] for a
+/// maximum.
+fn merge_numeric_bound(
+    current: &mut Value,
+    candidate: &Value,
+    path: &str,
+    unproven: &mut UnprovenPaths,
+    tighter: Ordering,
+) {
+    let ordering = match (current.as_number(), candidate.as_number()) {
+        (Some(held), Some(offered)) => json_numbers_cmp(offered, held),
+        _ => None,
+    };
+    match ordering {
+        Some(ordering) => {
+            if ordering == tighter {
+                *current = candidate.clone();
+            }
+        }
+        // Either side is not a number, or the pair has no exact order. Keeping
+        // the accumulated bound would claim an intersection nobody proved.
+        None => {
+            unproven.insert(path.to_owned());
         }
     }
 }
@@ -386,13 +493,21 @@ fn merge_schema_intersection(
     candidate: &Value,
     path: &str,
     unproven: &mut UnprovenPaths,
+    depth: usize,
 ) {
+    if depth >= MAX_RECURSION_DEPTH {
+        // Stop rather than merge deeper: the accumulated node keeps whatever it
+        // already holds, so the location must not be read as a proven
+        // intersection.
+        unproven.insert(path.to_owned());
+        return;
+    }
     match (&mut *target, candidate) {
         (Value::Bool(false), _) | (_, Value::Bool(true)) => {}
         (Value::Bool(true), value) => *target = value.clone(),
         (_, Value::Bool(false)) => *target = Value::Bool(false),
         (Value::Object(target_map), Value::Object(candidate_map)) => {
-            merge_schema_map(target_map, candidate_map, path, unproven);
+            merge_schema_map(target_map, candidate_map, path, unproven, depth);
         }
         _ => {
             // Two branches that are not both object schemas have no
@@ -405,7 +520,7 @@ fn merge_schema_intersection(
 }
 #[must_use]
 pub fn flatten_schema(schema: &Value) -> Value {
-    flatten_effective(schema).0
+    flatten_effective(schema, 0).0
 }
 
 /// Flattens `allOf` and reports where the intersection could not be proven.
@@ -413,27 +528,35 @@ pub fn flatten_schema(schema: &Value) -> Value {
 /// The flattened schema is always a usable approximation; the returned
 /// [`UnprovenPaths`] tell a compatibility checker which locations it must
 /// not draw conclusions about.
-fn flatten_effective(schema: &Value) -> (Value, UnprovenPaths) {
+fn flatten_effective(schema: &Value, depth: usize) -> (Value, UnprovenPaths) {
     let mut unproven = UnprovenPaths::new();
     let Some(schema_map) = schema.as_object() else {
         return (schema.clone(), unproven);
     };
-    let mut result = Value::Bool(true);
+    if depth >= MAX_RECURSION_DEPTH {
+        unproven.insert(String::new());
+        return (schema.clone(), unproven);
+    }
+    // An empty object is the same schema as `true` and starting from it saves
+    // copying this level's own keywords through the boolean arm below.
+    let mut result = Value::Object(Map::new());
     if let Some(all_of) = schema_map.get("allOf").and_then(Value::as_array) {
         for branch in all_of {
-            let (flattened_branch, branch_unproven) = flatten_effective(branch);
+            let (flattened_branch, branch_unproven) = flatten_effective(branch, depth + 1);
             unproven.extend(branch_unproven);
-            merge_schema_intersection(&mut result, &flattened_branch, "", &mut unproven);
+            merge_schema_intersection(&mut result, &flattened_branch, "", &mut unproven, depth);
         }
     }
-    let direct = Value::Object(
-        schema_map
-            .iter()
-            .filter(|(keyword, _)| keyword.as_str() != "allOf")
-            .map(|(keyword, value)| (keyword.clone(), value.clone()))
-            .collect(),
-    );
-    merge_schema_intersection(&mut result, &direct, "", &mut unproven);
+    if let Value::Object(result_map) = &mut result {
+        for (keyword, value) in schema_map {
+            // Already folded above; the remaining keywords are this level's own
+            // declaration.
+            if keyword == "allOf" {
+                continue;
+            }
+            merge_keyword(result_map, keyword, value, "", &mut unproven, depth);
+        }
+    }
     (result, unproven)
 }
 
@@ -835,7 +958,7 @@ fn check_type_compatibility(
                 let values = accepted_value_set(schema);
                 values.map_or(TypeSet::Any, |values| {
                     let mut names = Vec::new();
-                    for value in &values {
+                    for value in values {
                         let name = value_type(value).to_owned();
                         if !names.contains(&name) {
                             names.push(name);
@@ -890,19 +1013,18 @@ fn check_type_compatibility(
 ///
 /// An instance must satisfy every keyword present, so two coexisting
 /// keywords accept their intersection - possibly nothing at all.
-fn accepted_value_set(schema: &Map<String, Value>) -> Option<Vec<Value>> {
+fn accepted_value_set(schema: &Map<String, Value>) -> Option<Vec<&Value>> {
     // A non-array `enum` is not a valid constraint and nothing can be read
     // from it, which is what `as_array` returning `None` expresses here.
     let enumeration = schema.get("enum").and_then(Value::as_array);
     match (schema.get("const"), enumeration) {
         (None, None) => None,
-        (Some(constant), None) => Some(vec![constant.clone()]),
-        (None, Some(values)) => Some(values.clone()),
+        (Some(constant), None) => Some(vec![constant]),
+        (None, Some(values)) => Some(values.iter().collect()),
         (Some(constant), Some(values)) => Some(
             values
                 .iter()
                 .filter(|value| json_values_equal(value, constant))
-                .cloned()
                 .collect(),
         ),
     }
@@ -926,7 +1048,7 @@ fn enumerated_source_is_included(source: &Map<String, Value>, target: &Value) ->
     let Ok(validator) = jsonschema::validator_for(target) else {
         return false;
     };
-    values.iter().all(|value| validator.is_valid(value))
+    values.into_iter().all(|value| validator.is_valid(value))
 }
 
 /// Compares the value sets `const` and `enum` impose, as one set.
@@ -972,6 +1094,7 @@ fn check_value_set_compatibility(
         (Some(source), Some(target)) => {
             let incompatible_values: Vec<&Value> = source
                 .iter()
+                .copied()
                 .filter(|value| {
                     !target
                         .iter()
@@ -1081,30 +1204,39 @@ fn check_schema_node_compatibility(
     old_schema: &Value,
     new_schema: &Value,
     path: &str,
-    check_backward: bool,
-    dialects: DialectSupport,
+    walk: Walk,
     inherited_unproven: UnprovenPaths,
     errors: &mut Vec<CompatibilityDiagnostic>,
 ) {
+    let check_backward = walk.check_backward;
+    if walk.exhausted() {
+        errors.push(CompatibilityDiagnostic::new(
+            path,
+            CompatibilityFinding::NotProvable,
+            format!("nests deeper than the checker walks ({MAX_RECURSION_DEPTH} levels)"),
+        ));
+        return;
+    }
+
     // Locations an ancestor could not prove stay unprovable here; add
     // whatever this node's own `allOf` composition leaves undecided.
     let mut unproven = inherited_unproven;
     let old_effective = if old_schema.get("allOf").is_some() {
-        let (effective, paths) = flatten_effective(old_schema);
+        let (effective, paths) = flatten_effective(old_schema, walk.depth);
         unproven.extend(paths);
-        effective
+        Cow::Owned(effective)
     } else {
-        old_schema.clone()
+        Cow::Borrowed(old_schema)
     };
     let new_effective = if new_schema.get("allOf").is_some() {
-        let (effective, paths) = flatten_effective(new_schema);
+        let (effective, paths) = flatten_effective(new_schema, walk.depth);
         unproven.extend(paths);
-        effective
+        Cow::Owned(effective)
     } else {
-        new_schema.clone()
+        Cow::Borrowed(new_schema)
     };
 
-    let (source, target) = if check_backward {
+    let (source, target): (&Value, &Value) = if check_backward {
         (&old_effective, &new_effective)
     } else {
         (&new_effective, &old_effective)
@@ -1143,32 +1275,35 @@ fn check_schema_node_compatibility(
         return;
     }
 
-    let source_map = if check_backward { old_map } else { new_map };
-    if enumerated_source_is_included(source_map, target) {
-        return;
-    }
+    // Everything this node and its subtree find is collected locally first.
+    // `enumerated_source_is_included` can discharge all of it at once, but it
+    // costs a JSON Schema compilation of the whole counterpart subtree, so it
+    // is consulted only once there is something to discharge - otherwise a
+    // document carrying `const`/`enum` at every level pays one compilation per
+    // level to confirm what the cheap keyword comparison already showed.
+    let mut node_errors = Vec::new();
 
-    errors.extend(check_type_compatibility(
+    node_errors.extend(check_type_compatibility(
         path,
         old_map,
         new_map,
         check_backward,
     ));
-    errors.extend(check_value_set_compatibility(
+    node_errors.extend(check_value_set_compatibility(
         path,
         old_map,
         new_map,
         check_backward,
     ));
-    errors.extend(check_exact_constraints(path, old_map, new_map));
-    errors.extend(check_unresolved_ref(path, old_map, new_map));
-    errors.extend(check_narrowing_constraints(
+    node_errors.extend(check_exact_constraints(path, old_map, new_map));
+    node_errors.extend(check_unresolved_ref(path, old_map, new_map));
+    node_errors.extend(check_narrowing_constraints(
         path,
         old_map,
         new_map,
         check_backward,
     ));
-    errors.extend(check_constraint_compatibility(
+    node_errors.extend(check_constraint_compatibility(
         path,
         old_map,
         new_map,
@@ -1185,15 +1320,7 @@ fn check_schema_node_compatibility(
             || schema.contains_key("propertyNames")
     };
     if is_object_schema(old_map) || is_object_schema(new_map) {
-        check_object_compatibility(
-            old_map,
-            new_map,
-            path,
-            check_backward,
-            dialects,
-            &unproven,
-            errors,
-        );
+        check_object_compatibility(old_map, new_map, path, walk, &unproven, &mut node_errors);
     }
 
     match (old_map.get("items"), new_map.get("items")) {
@@ -1201,36 +1328,51 @@ fn check_schema_node_compatibility(
             old_items,
             new_items,
             &format!("{path}[]"),
-            check_backward,
-            dialects,
+            walk.deeper(),
             unproven_below(&unproven, "[]"),
-            errors,
+            &mut node_errors,
         ),
         (None, Some(_)) if check_backward => {
-            errors.push(CompatibilityDiagnostic::new(
+            node_errors.push(CompatibilityDiagnostic::new(
                 path,
                 CompatibilityFinding::ConstraintChanged,
                 "adds an array items constraint".to_owned(),
             ));
         }
-        (Some(_), None) if !check_backward => errors.push(CompatibilityDiagnostic::new(
+        (Some(_), None) if !check_backward => node_errors.push(CompatibilityDiagnostic::new(
             path,
             CompatibilityFinding::ConstraintChanged,
             "removes an array items constraint".to_owned(),
         )),
         _ => {}
     }
+
+    if node_errors.is_empty() {
+        return;
+    }
+    // The enumerated set covers the subtree as well as this level, so proving
+    // it discharges the nested findings too - which is why the whole walk is
+    // collected before this point rather than after it.
+    let source_map = if check_backward { old_map } else { new_map };
+    if enumerated_source_is_included(source_map, target) {
+        return;
+    }
+    errors.append(&mut node_errors);
 }
 
 fn check_object_compatibility(
     old_schema: &Map<String, Value>,
     new_schema: &Map<String, Value>,
     path: &str,
-    check_backward: bool,
-    dialects: DialectSupport,
+    walk: Walk,
     unproven: &UnprovenPaths,
     errors: &mut Vec<CompatibilityDiagnostic>,
 ) {
+    let Walk {
+        check_backward,
+        dialects,
+        ..
+    } = walk;
     let empty = Map::new();
     let old_props = old_schema
         .get("properties")
@@ -1314,8 +1456,7 @@ fn check_object_compatibility(
                 old_property,
                 new_property,
                 &property_path,
-                check_backward,
-                dialects,
+                walk.deeper(),
                 unproven_below(unproven, &format!(".{name}")),
                 errors,
             );
@@ -1327,8 +1468,7 @@ fn check_object_compatibility(
                 old_property,
                 counterpart,
                 &property_path,
-                check_backward,
-                dialects,
+                walk.deeper(),
                 UnprovenPaths::new(),
                 errors,
             );
@@ -1358,8 +1498,7 @@ fn check_object_compatibility(
                 counterpart,
                 new_property,
                 &property_path,
-                check_backward,
-                dialects,
+                walk.deeper(),
                 UnprovenPaths::new(),
                 errors,
             );
@@ -1433,13 +1572,19 @@ fn classify_content_model(schema: &Map<String, Value>, supports_unevaluated: boo
     }
 }
 
+/// Every pair is spelled out: a content model added later must fail to compile
+/// here rather than default to being a subset of everything.
 const fn content_model_is_subset(source: ContentModel, target: ContentModel) -> bool {
-    matches!(
-        (source, target),
-        (ContentModel::Closed, _)
-            | (_, ContentModel::Open)
-            | (ContentModel::Partial, ContentModel::Partial)
-    )
+    match (source, target) {
+        (
+            ContentModel::Closed,
+            ContentModel::Closed | ContentModel::Partial | ContentModel::Open,
+        )
+        | (ContentModel::Partial, ContentModel::Partial | ContentModel::Open)
+        | (ContentModel::Open, ContentModel::Open) => true,
+        (ContentModel::Partial | ContentModel::Open, ContentModel::Closed)
+        | (ContentModel::Open, ContentModel::Partial) => false,
+    }
 }
 
 fn partial_content_constraints_equal(
@@ -1597,10 +1742,13 @@ fn check_inclusion(
         old_schema,
         new_schema,
         "$",
-        check_backward,
-        DialectSupport {
-            old_unevaluated: dialect_supports_unevaluated(effective_old),
-            new_unevaluated: dialect_supports_unevaluated(effective_new),
+        Walk {
+            check_backward,
+            dialects: DialectSupport {
+                old_unevaluated: dialect_supports_unevaluated(effective_old),
+                new_unevaluated: dialect_supports_unevaluated(effective_new),
+            },
+            depth: 0,
         },
         UnprovenPaths::new(),
         &mut errors,
@@ -1643,20 +1791,34 @@ pub fn classify_object_levels(schema: &Value) -> Vec<ObjectLevel> {
     let dialect = schema.get("$schema").and_then(Value::as_str);
     let supports_unevaluated = dialect_supports_unevaluated(dialect);
     let mut levels = Vec::new();
-    collect_object_levels(schema, "$", supports_unevaluated, &mut levels);
+    collect_object_levels(schema, "$", supports_unevaluated, 0, &mut levels);
     levels
 }
 
+/// Levels below [`MAX_RECURSION_DEPTH`] are not reported.
+///
+/// This is the one bounded walk that truncates without a marker, because
+/// [`ContentModel`] spells the three models gts-spec §4.4 defines and "not
+/// looked at" is not one of them. It is safe only because the classification is
+/// advisory - it tells an owner where a later definition can still add an
+/// optional property, and never decides a compatibility relation. The relation
+/// itself is decided by [`check_inclusion`], whose own guard reports the same
+/// nesting as [`CompatibilityFinding::NotProvable`], so a document deep enough
+/// to truncate here is already refused there.
 fn collect_object_levels(
     schema: &Value,
     path: &str,
     supports_unevaluated: bool,
+    depth: usize,
     levels: &mut Vec<ObjectLevel>,
 ) {
+    if depth >= MAX_RECURSION_DEPTH {
+        return;
+    }
     let effective = if schema.get("allOf").is_some() {
-        flatten_schema(schema)
+        Cow::Owned(flatten_schema(schema))
     } else {
-        schema.clone()
+        Cow::Borrowed(schema)
     };
     let Some(map) = effective.as_object() else {
         return;
@@ -1682,11 +1844,23 @@ fn collect_object_levels(
             } else {
                 format!("{path}.{name}")
             };
-            collect_object_levels(property, &property_path, supports_unevaluated, levels);
+            collect_object_levels(
+                property,
+                &property_path,
+                supports_unevaluated,
+                depth + 1,
+                levels,
+            );
         }
     }
     if let Some(items) = map.get("items") {
-        collect_object_levels(items, &format!("{path}[]"), supports_unevaluated, levels);
+        collect_object_levels(
+            items,
+            &format!("{path}[]"),
+            supports_unevaluated,
+            depth + 1,
+            levels,
+        );
     }
 }
 /// Compares two JSON values the way JSON Schema compares instances.
@@ -1767,6 +1941,44 @@ fn json_numbers_equal(left: &serde_json::Number, right: &serde_json::Number) -> 
         // to compare.
         _ => left == right,
     }
+}
+
+/// Orders two JSON numbers exactly, or reports that the pair has no order.
+///
+/// The `f64` shortcut [`json_numbers_equal`] avoids for equality is just as
+/// wrong for ordering: rounding both sides would order `2^53 + 1` and `2^53` as
+/// equal, so a genuinely tighter bound would not be adopted and the flattened
+/// level would claim a looser intersection than the real one.
+fn json_numbers_cmp(left: &serde_json::Number, right: &serde_json::Number) -> Option<Ordering> {
+    if let (Some(left), Some(right)) = (left.as_u64(), right.as_u64()) {
+        return Some(left.cmp(&right));
+    }
+    if let (Some(left), Some(right)) = (left.as_i64(), right.as_i64()) {
+        return Some(left.cmp(&right));
+    }
+    // A mixed pair - one integer and one float, or the two integers no pair-up
+    // above could hold (one negative, one past `i64::MAX`). `num_cmp` orders
+    // these across representations without routing either through the other.
+    if let Some(left) = left.as_u64() {
+        return right
+            .as_f64()
+            .and_then(|right| NumCmp::num_cmp(left, right));
+    }
+    if let Some(left) = left.as_i64() {
+        return right
+            .as_f64()
+            .and_then(|right| NumCmp::num_cmp(left, right));
+    }
+    let left = left.as_f64()?;
+    if let Some(right) = right.as_u64() {
+        return NumCmp::num_cmp(left, right);
+    }
+    if let Some(right) = right.as_i64() {
+        return NumCmp::num_cmp(left, right);
+    }
+    // Neither side is representable as anything but a float, so this is the
+    // exact comparison; a value needing `arbitrary_precision` yields `None`.
+    left.partial_cmp(&right.as_f64()?)
 }
 
 /// Compares an integer-valued JSON number to a float, exactly.

--- a/gts/src/schema_evolution_test.rs
+++ b/gts/src/schema_evolution_test.rs
@@ -29,6 +29,22 @@ fn check_schema_compatibility(
     }
 }
 
+/// Asserts that the machine-readable classification - not just the verdict -
+/// is what the test says it is, at the location it says.
+#[track_caller]
+fn assert_finding(
+    diagnostics: &[CompatibilityDiagnostic],
+    path: &str,
+    finding: CompatibilityFinding,
+) {
+    assert!(
+        diagnostics
+            .iter()
+            .any(|diagnostic| diagnostic.path == path && diagnostic.finding == finding),
+        "expected {finding:?} at '{path}': {diagnostics:?}"
+    );
+}
+
 #[test]
 fn test_compatibility_verdict_serialization_and_full_derivation() {
     assert_eq!(
@@ -129,6 +145,11 @@ fn test_check_schema_compatibility_added_required_property() {
     let result = check_schema_compatibility(&old_schema, &new_schema);
     // Adding required property is not backward compatible
     assert!(result.backward_compatibility.is_incompatible());
+    assert_finding(
+        &check_backward_diagnostics(&old_schema, &new_schema).1,
+        "$",
+        CompatibilityFinding::RequiredChanged,
+    );
 }
 
 #[test]
@@ -187,6 +208,11 @@ fn test_check_schema_compatibility_enum_reduction() {
     assert!(result.backward_compatibility.is_incompatible());
     assert!(result.forward_compatibility.is_compatible());
     assert!(result.full_compatibility.is_incompatible());
+    assert_finding(
+        &check_backward_diagnostics(&old_schema, &new_schema).1,
+        "$",
+        CompatibilityFinding::EnumChanged,
+    );
 }
 
 #[test]
@@ -202,6 +228,12 @@ fn test_check_schema_compatibility_type_change() {
     let result = check_schema_compatibility(&old_schema, &new_schema);
     assert!(result.backward_compatibility.is_incompatible());
     assert!(result.forward_compatibility.is_incompatible());
+    for diagnostics in [
+        check_backward_diagnostics(&old_schema, &new_schema).1,
+        check_forward_diagnostics(&old_schema, &new_schema).1,
+    ] {
+        assert_finding(&diagnostics, "$", CompatibilityFinding::TypeChanged);
+    }
 }
 
 #[test]
@@ -803,6 +835,11 @@ fn test_dialect_change_is_not_proven_compatible() {
     let result = check_schema_compatibility(&old_schema, &new_schema);
     assert!(result.backward_compatibility.is_unknown());
     assert!(result.forward_compatibility.is_unknown());
+    assert_finding(
+        &check_backward_diagnostics(&old_schema, &new_schema).1,
+        "$",
+        CompatibilityFinding::DialectChanged,
+    );
 }
 
 #[test]
@@ -862,6 +899,29 @@ fn test_all_of_intersects_duplicate_property_schemas() {
         flattened.pointer("/properties/value/maxLength"),
         Some(&json!(10))
     );
+}
+
+/// An instance must satisfy every `allOf` branch, so the flattened level
+/// requires every name any branch requires - not the names of one branch.
+#[test]
+fn test_all_of_unions_required_across_branches() {
+    let schema = json!({
+        "allOf": [
+            {"type": "object", "required": ["a"]},
+            {"type": "object", "required": ["b"]}
+        ]
+    });
+
+    let flattened = flatten_schema(&schema);
+    let mut required: Vec<&str> = flattened
+        .pointer("/required")
+        .and_then(Value::as_array)
+        .expect("both branches declare 'required', so the flattened level has it")
+        .iter()
+        .filter_map(Value::as_str)
+        .collect();
+    required.sort_unstable();
+    assert_eq!(required, ["a", "b"]);
 }
 
 #[test]
@@ -956,15 +1016,22 @@ fn test_identical_unresolved_ref_needs_no_resolution() {
 }
 
 fn property_change(old_property: Value, new_property: Value) -> CompatibilityResult {
-    let document = |property: Value| {
-        json!({
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {"value": property},
-            "required": ["value"]
-        })
-    };
-    check_schema_compatibility(&document(old_property), &document(new_property))
+    check_schema_compatibility(
+        &property_document(old_property),
+        &property_document(new_property),
+    )
+}
+
+/// A closed object whose single required property carries the schema under test.
+// By-value `json!(...)` literals read cleaner at the call sites.
+#[allow(clippy::needless_pass_by_value)]
+fn property_document(property: Value) -> Value {
+    json!({
+        "type": "object",
+        "additionalProperties": false,
+        "properties": {"value": property},
+        "required": ["value"]
+    })
 }
 
 /// Bound keywords must be compared whenever present, never gated on `type`.
@@ -975,6 +1042,15 @@ fn test_numeric_bounds_are_checked_without_a_type_keyword() {
     let result = property_change(json!({"minimum": 0}), json!({"minimum": 5}));
     assert!(result.backward_compatibility.is_incompatible());
     assert!(result.forward_compatibility.is_compatible());
+    assert_finding(
+        &check_backward_diagnostics(
+            &property_document(json!({"minimum": 0})),
+            &property_document(json!({"minimum": 5})),
+        )
+        .1,
+        "$.value",
+        CompatibilityFinding::BoundChanged,
+    );
 
     let result = property_change(
         json!({"type": ["integer"], "minimum": 0}),
@@ -1494,15 +1570,15 @@ fn test_unprovable_intersection_leaves_no_synthetic_keyword() {
         ]
     }));
 
-    let keys: Vec<&String> = flattened
+    // An exact key set, because bookkeeping that leaks under any name at all
+    // is what this guards against.
+    let keys: Vec<&str> = flattened
         .as_object()
         .expect("flattening object branches yields an object")
         .keys()
+        .map(String::as_str)
         .collect();
-    assert!(
-        keys.iter().all(|key| !key.starts_with("x-gts-internal")),
-        "{keys:?}"
-    );
+    assert_eq!(keys, ["additionalProperties", "type"]);
 }
 
 /// The undecidable branch must stay local: reporting it must not swallow a
@@ -1538,5 +1614,151 @@ fn test_unprovable_property_does_not_mask_sibling_incompatibility() {
             .iter()
             .any(|diagnostic| diagnostic.path == "$.sibling"),
         "{diagnostics:?}"
+    );
+}
+
+/// `depth` object levels, each holding the next under `next`.
+fn nested_objects(depth: usize) -> Value {
+    let mut schema = json!({"type": "string"});
+    for _ in 0..depth {
+        schema = json!({"type": "object", "properties": {"next": schema}});
+    }
+    schema
+}
+
+/// `depth` `allOf` wrappers around one object level.
+fn nested_all_of(depth: usize) -> Value {
+    let mut schema = json!({"type": "object", "properties": {"v": {"type": "string"}}});
+    for _ in 0..depth {
+        schema = json!({"allOf": [schema]});
+    }
+    schema
+}
+
+/// `$ref` resolution can hand the checker a tree deeper than anything a client
+/// authored, so the walk stops - and says so, rather than reporting the levels
+/// it never compared as compatible.
+#[test]
+fn test_nesting_beyond_the_walk_is_reported_as_not_provable() {
+    let (verdict, diagnostics) =
+        check_backward_diagnostics(&nested_objects(200), &nested_objects(200));
+    assert!(verdict.is_unknown(), "{diagnostics:?}");
+    assert!(
+        diagnostics.iter().any(|diagnostic| diagnostic.finding
+            == CompatibilityFinding::NotProvable
+            && diagnostic.detail.contains("nests deeper")),
+        "{diagnostics:?}"
+    );
+}
+
+/// The flattener has its own bound, driven by nested `allOf` rather than by
+/// nested properties, so it needs its own case: a branch it stopped merging
+/// must read as an unproven intersection and never as a proven one.
+#[test]
+fn test_all_of_nested_beyond_the_flattener_is_not_provable() {
+    let (verdict, diagnostics) =
+        check_backward_diagnostics(&nested_all_of(200), &nested_all_of(200));
+    assert!(verdict.is_unknown(), "{diagnostics:?}");
+    assert!(
+        diagnostics.iter().any(|diagnostic| diagnostic.finding
+            == CompatibilityFinding::NotProvable
+            && diagnostic.detail.contains("allOf intersection")),
+        "{diagnostics:?}"
+    );
+}
+
+/// The level classification stops at the same bound and, unlike every other
+/// bounded walk here, reports nothing for what it skipped - `ContentModel` has
+/// no "not looked at" variant. That is safe only because it is advisory: the
+/// relation over the very same document is refused rather than decided.
+#[test]
+fn test_object_levels_stop_at_the_walk_bound_while_the_verdict_refuses() {
+    let deep = nested_objects(200);
+
+    let levels = classify_object_levels(&deep);
+    assert_eq!(levels.len(), MAX_RECURSION_DEPTH, "{}", levels.len());
+    assert!(
+        levels
+            .iter()
+            .all(|level| level.content_model == ContentModel::Open),
+        "{levels:?}"
+    );
+
+    let (verdict, diagnostics) = check_backward_diagnostics(&deep, &deep);
+    assert!(
+        verdict.is_unknown(),
+        "the advisory truncation must not be the only signal: {diagnostics:?}"
+    );
+}
+
+/// A finite accepted-value set proves inclusion for the *whole* subtree, so it
+/// discharges nested findings and not only this level's keywords.
+///
+/// This is what fixes the order of the node walk: the enumerated proof is
+/// attempted only once something needs discharging, which means the nested
+/// comparison has to have run already.
+#[test]
+fn test_enumerated_source_discharges_a_nested_narrowing() {
+    let old_schema = json!({
+        "type": "object",
+        "properties": {"x": {"type": "integer"}},
+        "const": {"x": 1}
+    });
+    // Narrower on the nested property, but every value `old` accepts still
+    // validates against it.
+    let new_schema = json!({
+        "type": "object",
+        "properties": {"x": {"type": "integer", "minimum": 0, "maximum": 10}}
+    });
+
+    let (verdict, diagnostics) = check_backward_diagnostics(&old_schema, &new_schema);
+    assert!(verdict.is_compatible(), "{diagnostics:?}");
+
+    // Without the enumerated value the same narrowing is reported, so the
+    // assertion above is about the proof and not about a checker that ignores
+    // nested bounds.
+    let mut unconstrained = old_schema;
+    unconstrained.as_object_mut().expect("test").remove("const");
+    let (verdict, diagnostics) = check_backward_diagnostics(&unconstrained, &new_schema);
+    assert!(verdict.is_incompatible(), "{diagnostics:?}");
+    assert_finding(&diagnostics, "$.x", CompatibilityFinding::BoundChanged);
+}
+
+/// Bounds are intersected by exact numeric order, not through `f64`.
+///
+/// `2^53 + 1` and `2^53` are the same double, so rounding both sides would order
+/// them equal and keep the looser branch - the flattened level would then claim
+/// a weaker `minimum` than the real intersection.
+#[test]
+fn test_all_of_intersects_bounds_beyond_f64_precision() {
+    // Both round to the same f64, so an f64 comparison cannot tell them apart.
+    const TIGHTER: u64 = (1_u64 << 53) + 1;
+    const LOOSER: u64 = 1_u64 << 53;
+
+    // The tighter minimum arrives second, so an f64 comparison reports "not
+    // greater" and discards it.
+    let flattened = flatten_schema(&json!({
+        "allOf": [
+            {"type": "integer", "minimum": LOOSER},
+            {"type": "integer", "minimum": TIGHTER}
+        ]
+    }));
+    assert_eq!(
+        flattened.pointer("/minimum").and_then(Value::as_u64),
+        Some(TIGHTER),
+        "{flattened}"
+    );
+
+    // And the reverse order must not loosen an already tighter bound.
+    let flattened = flatten_schema(&json!({
+        "allOf": [
+            {"type": "integer", "minimum": TIGHTER},
+            {"type": "integer", "minimum": LOOSER}
+        ]
+    }));
+    assert_eq!(
+        flattened.pointer("/minimum").and_then(Value::as_u64),
+        Some(TIGHTER),
+        "{flattened}"
     );
 }

--- a/gts/src/schema_resolver.rs
+++ b/gts/src/schema_resolver.rs
@@ -26,6 +26,25 @@ pub(crate) trait SchemaProvider {
     fn schema_content(&self, type_id: &str) -> Option<&Value>;
 }
 
+/// Longest chain of nested `$ref`s that will be inlined.
+///
+/// A single posted document is bounded by the JSON parser's own nesting limit,
+/// but inlining walks from one registered document into the next, so the
+/// resolved body's depth is the product of the chain length and each link's
+/// depth. Bounding the chain bounds the tree every later walk - compatibility,
+/// flattening, content-model classification - has to descend.
+///
+/// `visited` holds exactly the refs whose resolution is in progress on the
+/// current path, so its size *is* the current chain depth.
+///
+/// This is a hard refusal, not a truncation: a chain longer than the budget is
+/// reported as [`StoreError::UnresolvedRefs`], so a document that resolved
+/// before this bound existed no longer does. The budget is deliberately far
+/// above any authored `$id` derivation chain - the gts-spec conformance suite
+/// resolves well inside it - and no caller can raise it, because the tree it
+/// bounds is what every later walk has to descend.
+const MAX_REF_CHAIN_DEPTH: usize = 32;
+
 /// Inlines `$ref`s in a JSON Schema using a [`SchemaProvider`] for lookups.
 pub(crate) struct SchemaResolver<'a> {
     provider: &'a dyn SchemaProvider,
@@ -99,6 +118,13 @@ impl<'a> SchemaResolver<'a> {
                                     format!("local:{:p}:{ref_uri}", std::ptr::from_ref(local_root));
                                 if visited.contains(&local_ref_key) {
                                     *cycle_found = true;
+                                    return Value::Object(map.clone());
+                                }
+                                if visited.len() >= MAX_REF_CHAIN_DEPTH {
+                                    unresolved_refs.push(format!(
+                                        "{ref_uri} (nested deeper than \
+                                         {MAX_REF_CHAIN_DEPTH} chained $refs)"
+                                    ));
                                     return Value::Object(map.clone());
                                 }
                                 if let Some(target) = local_root.pointer(pointer) {
@@ -183,6 +209,14 @@ impl<'a> SchemaResolver<'a> {
                             );
                         }
                         return Value::Object(new_map);
+                    }
+
+                    if visited.len() >= MAX_REF_CHAIN_DEPTH {
+                        unresolved_refs.push(format!(
+                            "{canonical_ref} (nested deeper than \
+                             {MAX_REF_CHAIN_DEPTH} chained $refs)"
+                        ));
+                        return Value::Object(map.clone());
                     }
 
                     // Try to resolve the reference using the canonical ID

--- a/gts/src/schema_resolver_test.rs
+++ b/gts/src/schema_resolver_test.rs
@@ -793,3 +793,53 @@ fn test_resolve_circular_ref_does_not_hang() {
         StoreError::CircularRef
     ));
 }
+
+/// Builds `links` registered documents, each `$ref`ing the next, and resolves a
+/// root pointing at the first.
+///
+/// Each link wraps the next one, so the resolved root nests `links` levels deep
+/// even though no single document nests at all - which is the shape
+/// [`super::MAX_REF_CHAIN_DEPTH`] exists to bound.
+fn resolve_ref_chain(links: usize) -> Result<Value, StoreError> {
+    let id = |index: usize| format!("gts.x.test.chain.n{index}.v1~");
+    let mut provider = MapProvider::new();
+    for index in 0..links {
+        let content = if index + 1 == links {
+            json!({"type": "object"})
+        } else {
+            json!({
+                "type": "object",
+                "properties": {"next": {"$ref": format!("gts://{}", id(index + 1))}}
+            })
+        };
+        provider = provider.with(&id(index), content);
+    }
+    SchemaResolver::new(&provider).resolve(&json!({"$ref": format!("gts://{}", id(0))}))
+}
+
+/// A long `$ref` chain multiplies each link's own nesting into the resolved
+/// body, so it is refused rather than inlined - every later walk descends the
+/// tree this produces.
+///
+/// Both sides of the budget are asserted, so it can be neither silently
+/// tightened (which would refuse documents that must resolve) nor loosened.
+#[test]
+fn test_resolve_refuses_a_ref_chain_past_the_budget() {
+    let resolved = resolve_ref_chain(super::MAX_REF_CHAIN_DEPTH)
+        .expect("a chain exactly at the budget must still resolve");
+    // Fully inlined: nothing is left pointing outwards.
+    assert!(
+        !resolved.to_string().contains("$ref"),
+        "chain at the budget must be inlined: {resolved}"
+    );
+
+    let error = resolve_ref_chain(super::MAX_REF_CHAIN_DEPTH + 1)
+        .expect_err("one link past the budget must not resolve");
+    let StoreError::UnresolvedRefs(refs) = error else {
+        panic!("expected the over-long chain to be reported as unresolved: {error:?}");
+    };
+    assert!(
+        refs.iter().any(|entry| entry.contains("chained $refs")),
+        "{refs:?}"
+    );
+}

--- a/gts/src/schema_traits.rs
+++ b/gts/src/schema_traits.rs
@@ -667,7 +667,10 @@ fn materialize_traits(trait_schema: &Value, traits: &Value) -> Value {
 
 /// Per-property materialization view: (most-derived declaration, nearest
 /// `default`).
-type PropResolution = (Value, Option<Value>);
+///
+/// Borrowed from the collected declarations, which already own one deep copy
+/// each: the only owning clone is the value actually inserted into the result.
+type PropResolution<'a> = (&'a Value, Option<&'a Value>);
 
 fn materialize_traits_recursive(trait_schema: &Value, traits: &Value, depth: usize) -> Value {
     if depth >= MAX_RECURSION_DEPTH {
@@ -691,32 +694,32 @@ fn materialize_traits_recursive(trait_schema: &Value, traits: &Value, depth: usi
     // to descendants even when a descendant redeclares the property without one
     // (gts-spec §9.7.2, ADR-0003). The most-derived declaration also drives the
     // "recurse into nested object" decision.
-    let mut order: Vec<String> = Vec::new();
-    let mut resolved: std::collections::HashMap<String, PropResolution> =
+    let mut order: Vec<&str> = Vec::new();
+    let mut resolved: std::collections::HashMap<&str, PropResolution<'_>> =
         std::collections::HashMap::new();
     for (name, sch) in all_props.iter().rev() {
         let obj = sch.as_object();
-        let entry = resolved.entry(name.clone()).or_insert_with(|| {
-            order.push(name.clone());
-            (sch.clone(), None)
+        let entry = resolved.entry(name.as_str()).or_insert_with(|| {
+            order.push(name.as_str());
+            (sch, None)
         });
         if entry.1.is_none()
             && let Some(default_val) = obj.and_then(|o| o.get("default"))
         {
-            entry.1 = Some(default_val.clone());
+            entry.1 = Some(default_val);
         }
     }
 
     for name in &order {
-        let (prop_schema, nearest_default) = &resolved[name];
-        if !result.contains_key(name.as_str()) {
+        let (prop_schema, nearest_default) = resolved[name];
+        if !result.contains_key(*name) {
             // Property is absent — fill from the nearest `default` up the chain.
             // A `const` is not substituted here: it asserts the value of a
             // present property, it does not supply a missing one.
             if let Some(default_val) = nearest_default {
-                result.insert(name.clone(), default_val.clone());
+                result.insert((*name).to_owned(), default_val.clone());
             }
-        } else if result.get(name.as_str()).is_some_and(Value::is_object)
+        } else if result.get(*name).is_some_and(Value::is_object)
             && prop_schema.as_object().is_some_and(|o| {
                 o.get("type") == Some(&Value::String("object".to_owned()))
                     && o.contains_key("properties")
@@ -728,10 +731,10 @@ fn materialize_traits_recursive(trait_schema: &Value, traits: &Value, depth: usi
             // object doesn't mask the type error from later validation.
             let nested = materialize_traits_recursive(
                 prop_schema,
-                result.get(name.as_str()).unwrap_or(&Value::Null),
+                result.get(*name).unwrap_or(&Value::Null),
                 depth + 1,
             );
-            result.insert(name.clone(), nested);
+            result.insert((*name).to_owned(), nested);
         }
     }
 

--- a/gts/src/store.rs
+++ b/gts/src/store.rs
@@ -10,6 +10,7 @@ use crate::schema_evolution::{
     CompatibilityDiagnostic, CompatibilityVerdict, ObjectLevel, check_backward_diagnostics,
     check_forward_diagnostics, classify_object_levels,
 };
+use crate::schema_resolver::SchemaProvider;
 
 #[derive(Debug, Error)]
 pub enum StoreError {
@@ -53,13 +54,8 @@ pub struct GtsStoreQueryResult {
 /// is a policy decision for the caller, and gts-spec §6 leaves the enforced mode
 /// to the implementation.
 #[derive(Debug, Clone, Serialize, Deserialize)]
+#[must_use = "the compatibility verdict must be inspected"]
 pub struct SchemaComparison {
-    /// `Valid(old) ⊆ Valid(new)`: the new definition accepts every instance the
-    /// old one accepted.
-    pub backward_compatibility: CompatibilityVerdict,
-    /// `Valid(new) ⊆ Valid(old)`: the old definition accepts every instance the
-    /// new one accepts.
-    pub forward_compatibility: CompatibilityVerdict,
     /// Evidence for an incompatible or unknown backward verdict, with the
     /// offending schema location on each entry.
     pub backward_diagnostics: Vec<CompatibilityDiagnostic>,
@@ -78,21 +74,36 @@ pub struct SchemaComparison {
 }
 
 impl SchemaComparison {
+    /// `Valid(old) ⊆ Valid(new)`: the new definition accepts every instance the
+    /// old one accepted.
+    ///
+    /// Recomputed from [`Self::backward_diagnostics`] rather than stored beside
+    /// them. A verdict is entirely a reading of its evidence, so keeping a copy
+    /// would let a value exist - most easily one that was deserialized - that
+    /// reports `Compatible` next to a non-empty diagnostic list.
+    #[must_use]
+    pub fn backward_compatibility(&self) -> CompatibilityVerdict {
+        CompatibilityVerdict::from_diagnostics(&self.backward_diagnostics)
+    }
+
+    /// `Valid(new) ⊆ Valid(old)`: the old definition accepts every instance the
+    /// new one accepts. Recomputed like [`Self::backward_compatibility`].
+    #[must_use]
+    pub fn forward_compatibility(&self) -> CompatibilityVerdict {
+        CompatibilityVerdict::from_diagnostics(&self.forward_diagnostics)
+    }
+
     /// `Valid(old) = Valid(new)`: both directions hold.
     #[must_use]
-    pub const fn full_compatibility(&self) -> CompatibilityVerdict {
-        CompatibilityVerdict::full(self.backward_compatibility, self.forward_compatibility)
+    pub fn full_compatibility(&self) -> CompatibilityVerdict {
+        CompatibilityVerdict::full(self.backward_compatibility(), self.forward_compatibility())
     }
 
     /// Compares two documents whose references are already resolved.
     fn of_resolved(old_schema: &Value, new_schema: &Value) -> Self {
-        let (backward_compatibility, backward_diagnostics) =
-            check_backward_diagnostics(old_schema, new_schema);
-        let (forward_compatibility, forward_diagnostics) =
-            check_forward_diagnostics(old_schema, new_schema);
+        let (_, backward_diagnostics) = check_backward_diagnostics(old_schema, new_schema);
+        let (_, forward_diagnostics) = check_forward_diagnostics(old_schema, new_schema);
         Self {
-            backward_compatibility,
-            forward_compatibility,
             backward_diagnostics,
             forward_diagnostics,
             candidate_object_levels: classify_object_levels(new_schema),
@@ -852,16 +863,21 @@ impl GtsStore {
             .map_err(|e| StoreError::SchemaNotFound(e.to_string()))
     }
 
-    /// Fetches one side of a compatibility comparison, rendering the failure as
-    /// the message the result carries.
+    /// Admits one side of a compatibility comparison and warms the reader
+    /// cache, rendering the failure as the message the result carries.
+    ///
+    /// Returns nothing on success on purpose: the entity is read back through a
+    /// shared borrow afterwards, so both documents can be reached at once
+    /// without cloning either. The `&mut self` here is only what the lazy
+    /// reader fallback in [`Self::get`] needs.
     ///
     /// A missing schema keeps the historical `"Schema not found"` wording, which
     /// clients match on; every other cause - a malformed type id, an id naming a
     /// registered non-schema entity - reports itself, so the caller can tell an
     /// unregistered type from a request it should not have made at all.
-    fn compared_schema_entity(&mut self, type_id: &str) -> Result<GtsEntity, String> {
+    fn admit_compared_schema(&mut self, type_id: &str) -> Result<(), String> {
         self.get_schema_entity(type_id)
-            .cloned()
+            .map(|_| ())
             .map_err(|error| match error {
                 StoreError::SchemaNotFound(_) => "Schema not found".to_owned(),
                 error => error.to_string(),
@@ -869,19 +885,14 @@ impl GtsStore {
     }
 
     /// Checks GTS schema-evolution compatibility using accepted-instance set inclusion.
+    #[must_use = "the compatibility verdict and its diagnostics are the result of the check"]
     pub fn is_compatible(&mut self, old_type_id: &str, new_type_id: &str) -> GtsEntityCastResult {
-        let entities = self
-            .compared_schema_entity(old_type_id)
-            .and_then(|old_ent| {
-                self.compared_schema_entity(new_type_id)
-                    .map(|new_ent| (old_ent, new_ent))
-            });
-        let (old_ent, new_ent) = match entities {
-            Ok(entities) => entities,
-            Err(message) => {
-                return GtsEntityCastResult::undecided(old_type_id, new_type_id, message);
-            }
-        };
+        if let Err(message) = self
+            .admit_compared_schema(old_type_id)
+            .and_then(|()| self.admit_compared_schema(new_type_id))
+        {
+            return GtsEntityCastResult::undecided(old_type_id, new_type_id, message);
+        }
 
         let resolution_failure = |message: String| {
             GtsEntityCastResult::undecided_with_direction(
@@ -891,7 +902,21 @@ impl GtsStore {
                 message,
             )
         };
-        let old_schema = match self.resolve_schema_refs(&old_ent.content) {
+        // Both ids named a registered schema above and are now cached, so a
+        // shared borrow reaches each document in place. `resolve_schema_refs`
+        // also takes `&self` and returns a fresh owned document, so neither
+        // side needs a clone of the registered entity.
+        let (Some(old_content), Some(new_content)) = (
+            self.schema_content(old_type_id),
+            self.schema_content(new_type_id),
+        ) else {
+            return GtsEntityCastResult::undecided(
+                old_type_id,
+                new_type_id,
+                "Schema not found".to_owned(),
+            );
+        };
+        let old_schema = match self.resolve_schema_refs(old_content) {
             Ok(schema) => schema,
             Err(error) => {
                 return resolution_failure(format!(
@@ -899,7 +924,7 @@ impl GtsStore {
                 ));
             }
         };
-        let new_schema = match self.resolve_schema_refs(&new_ent.content) {
+        let new_schema = match self.resolve_schema_refs(new_content) {
             Ok(schema) => schema,
             Err(error) => {
                 return resolution_failure(format!(
@@ -909,8 +934,8 @@ impl GtsStore {
         };
 
         let comparison = SchemaComparison::of_resolved(&old_schema, &new_schema);
-        let backward_compatibility = comparison.backward_compatibility;
-        let forward_compatibility = comparison.forward_compatibility;
+        let backward_compatibility = comparison.backward_compatibility();
+        let forward_compatibility = comparison.forward_compatibility();
         let full_compatibility = comparison.full_compatibility();
         let backward_errors = comparison.backward_messages();
         let forward_errors = comparison.forward_messages();
@@ -942,8 +967,9 @@ impl GtsStore {
             incompatibility_reasons,
             backward_errors,
             forward_errors,
-            specification_version: crate::GTS_SPECIFICATION_VERSION.to_owned(),
-            implementation_version: crate::GTS_IMPLEMENTATION_VERSION.to_owned(),
+            // Produced here, so this build's versions are the provenance.
+            specification_version: Some(crate::GTS_SPECIFICATION_VERSION.to_owned()),
+            implementation_version: Some(crate::GTS_IMPLEMENTATION_VERSION.to_owned()),
             casted_entity: None,
             error: None,
         }
@@ -988,6 +1014,7 @@ impl GtsStore {
     ///
     /// Compatibility is no longer defined specifically in terms of a minor
     /// version change; callers should prefer [`Self::is_compatible`].
+    #[must_use = "the compatibility verdict and its diagnostics are the result of the check"]
     pub fn is_minor_compatible(
         &mut self,
         old_type_id: &str,

--- a/gts/src/store_test.rs
+++ b/gts/src/store_test.rs
@@ -6039,12 +6039,27 @@ fn test_compare_documents_resolves_and_reports_levels() {
     // Adding an optional property at a closed level is backward compatible and
     // not forward compatible (sec 4.5).
     assert!(
-        comparison.backward_compatibility.is_compatible(),
+        comparison.backward_compatibility().is_compatible(),
         "{:?}",
         comparison.backward_diagnostics
     );
-    assert!(comparison.forward_compatibility.is_incompatible());
+    assert!(comparison.forward_compatibility().is_incompatible());
     assert!(comparison.full_compatibility().is_incompatible());
+
+    // Both directions report separately: the added property is invisible to the
+    // backward check and is the whole of the forward one.
+    assert!(
+        comparison.backward_diagnostics.is_empty(),
+        "{:?}",
+        comparison.backward_diagnostics
+    );
+    let forward = comparison
+        .forward_diagnostics
+        .iter()
+        .find(|diagnostic| diagnostic.path == "$.payload")
+        .expect("the forward diagnostic must name the level that gained the property");
+    assert_eq!(forward.finding, crate::CompatibilityFinding::PropertyAdded);
+    assert!(forward.to_string().contains("'b'"), "{forward}");
 
     // The root is closed only through the resolved `$ref` to the envelope.
     let levels: std::collections::HashMap<&str, crate::ContentModel> = comparison
@@ -6083,7 +6098,7 @@ fn test_compare_documents_names_the_open_level() {
         .compare_documents(&revision(false), &revision(true))
         .expect("documents without references resolve trivially");
 
-    assert!(comparison.backward_compatibility.is_incompatible());
+    assert!(comparison.backward_compatibility().is_incompatible());
     let diagnostic = comparison
         .backward_diagnostics
         .iter()
@@ -6312,5 +6327,54 @@ fn test_validate_instance_reports_unresolvable_ref() {
     assert!(
         err.to_string()
             .contains("Unresolved $ref(s): gts://gts.vendor.package.namespace.nonexistent.v1.0~")
+    );
+}
+
+/// A `SchemaComparison` read back from a payload cannot report a verdict its
+/// diagnostics contradict, because there is no verdict field to contradict
+/// through - both directions are derived on read.
+#[test]
+fn test_comparison_verdicts_are_derived_from_diagnostics() {
+    let comparison: SchemaComparison = serde_json::from_value(json!({
+        "backward_diagnostics": [],
+        "forward_diagnostics": [
+            {"path": "$.payload", "finding": "property_added", "detail": "declares property 'b'"}
+        ],
+        "candidate_object_levels": []
+    }))
+    .expect("a comparison is fully described by its evidence");
+
+    assert!(comparison.backward_compatibility().is_compatible());
+    assert!(comparison.forward_compatibility().is_incompatible());
+    assert!(comparison.full_compatibility().is_incompatible());
+
+    // An inconclusive finding leaves the relation undecided rather than broken.
+    let unproven: SchemaComparison = serde_json::from_value(json!({
+        "backward_diagnostics": [
+            {"path": "$", "finding": "not_provable", "detail": "cannot prove"}
+        ],
+        "forward_diagnostics": [],
+        "candidate_object_levels": []
+    }))
+    .expect("test");
+    assert!(unproven.backward_compatibility().is_unknown());
+    assert!(unproven.full_compatibility().is_unknown());
+
+    // The verdict is absent from the serialized form, so nothing can carry a
+    // stale copy of it forward.
+    let json = serde_json::to_value(&comparison).expect("test");
+    let keys: Vec<&str> = json
+        .as_object()
+        .expect("test")
+        .keys()
+        .map(String::as_str)
+        .collect();
+    assert_eq!(
+        keys,
+        [
+            "backward_diagnostics",
+            "candidate_object_levels",
+            "forward_diagnostics"
+        ]
     );
 }


### PR DESCRIPTION
- Preserve absent GTS ID and result version provenance instead of conflating it with v0.
- Derive compatibility verdicts from diagnostics and bound recursive schema resolution.
- Correct additional-properties and trait materialization behavior with regression coverage.

This is a follow-up PR for https://github.com/GlobalTypeSystem/gts-rust/pull/110

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Compatibility results now preserve optional schema version information.
  * Compatibility analysis provides clearer verdicts and more detailed diagnostics.
  * Schema processing handles recursive schemas and references safely with depth limits.
  * Expanded support for nested models, flattened properties, and `additionalProperties`.

* **Bug Fixes**
  * Preserved the distinction between unspecified versions and explicit version zero.
  * Improved handling of complex schema combinations and malformed constraints.
  * Prevented excessive recursion during schema comparison and reference resolution.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->